### PR TITLE
feat: adjust generated name by chanaging case

### DIFF
--- a/examples/options.sh
+++ b/examples/options.sh
@@ -1,12 +1,12 @@
 # @describe    All kind of options
-# @option      -a --opta           A option
-# @option      -b --optb!          A required option
-# @option      -c --optc*          A option with multiple values
-# @option      -d --optd+          A required option with multiple values
-# @option      -e --opte=a         A option with default value
-# @option      -x --optx[x|y|z]    A option with choices
-# @option      -y --opty[=x|y|z]   A option with choices and default value
-# @option      -z --optz![x|y|z]   A required option with choices
+# @option      -a --opt1           A option
+# @option      -b --opt2!          A required option
+# @option      -c --opt3*          A option with multiple values
+# @option      -d --opt4+          A required option with multiple values
+# @option      -e --opt5=a         A option with default value
+# @option      -x --opt6[x|y|z]    A option with choices
+# @option      -y --opt7[=x|y|z]   A option with choices and default value
+# @option      -z --opt8![x|y|z]   A required option with choices
 
 eval "$(argc -e $0 "$@")"
 

--- a/examples/subcmds.sh
+++ b/examples/subcmds.sh
@@ -1,50 +1,50 @@
 
 # @cmd A simple positional argument
 # @arg value 
-cmda() {
+cmd1() {
     :;
 }
 
 # @cmd A required positional argument
 # @arg value!
-cmdb() {
+cmd2() {
     :;
 }
 
 # @cmd A positional argument support multiple values
 # @arg value*
-cmdc() {
+cmd3() {
     :;
 }
 
 # @cmd A required positional argument support multiple values
 # @arg value*
-cmdd() {
+cmd4() {
     :;
 }
 
 # @cmd A positional argument with default value
 # @arg value=a
-cmde() {
+cmd5() {
     :;
 }
 
 # @cmd A positional argument with choices
 # @arg value[x|y|z]
-cmdx() {
+cmd6() {
     :;
 }
 
 
 # @cmd A positional argument with choices and default value
 # @arg value[=x|y|z]
-cmdy() {
+cmd7() {
     :;
 }
 
 # @cmd A required positional argument with choices
 # @arg value![x|y|z]
-cmdz() {
+cmd8() {
     :;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod parser;
+mod utils;
 
 use anyhow::Error;
 pub use cli::{run, Runner};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,79 @@
+use convert_case::{Boundary, Converter, Pattern};
+
+/// Transform into a lower case string with underscores between words. `foo-bar` => `foo_bar`
+pub fn to_snake_case(value: &str) -> String {
+    Converter::new()
+        .set_pattern(Pattern::Lowercase)
+        .set_delim("_")
+        .set_boundaries(&[Boundary::Underscore, Boundary::LowerUpper, Boundary::Hyphen])
+        .convert(value)
+}
+
+/// Transform into a lower cased string with dashes between words. `foo_bar` => `foo-bar`
+pub fn to_kebab_case(value: &str) -> String {
+    Converter::new()
+        .set_pattern(Pattern::Lowercase)
+        .set_delim("-")
+        .set_boundaries(&[
+            Boundary::Underscore,
+            Boundary::LowerUpper,
+            Boundary::Underscore,
+        ])
+        .convert(value)
+}
+
+/// Transform into upper case string with an underscore between words. `foo-bar` => `FOO-BAR`
+pub fn to_cobol_case(value: &str) -> String {
+    Converter::new()
+        .set_pattern(Pattern::Uppercase)
+        .set_delim("-")
+        .set_boundaries(&[Boundary::Underscore, Boundary::LowerUpper, Boundary::Hyphen])
+        .convert(value)
+}
+
+pub fn escape_shell_words(value: &str) -> String {
+    let mut output = String::new();
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    for ch in value.chars() {
+        match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '-' | '.' | ',' | ':' | '/' | '@' => {
+                output.push(ch)
+            }
+            '\n' => output.push_str("'\n'"),
+            _ => {
+                output.push('\\');
+                output.push(ch);
+            }
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snake() {
+        assert_eq!("foo_bar".to_string(), to_snake_case("fooBar"));
+        assert_eq!("foo_bar".to_string(), to_snake_case("foo-bar"));
+        assert_eq!("foo_bar".to_string(), to_snake_case("foo_bar"));
+        assert_eq!("foo1".to_string(), to_snake_case("foo1"));
+    }
+
+    #[test]
+    fn test_kebab() {
+        assert_eq!("foo-bar".to_string(), to_kebab_case("fooBar"));
+        assert_eq!("foo-bar".to_string(), to_kebab_case("foo_bar"));
+        assert_eq!("foo1".to_string(), to_kebab_case("foo1"));
+    }
+
+    #[test]
+    fn test_cobol() {
+        assert_eq!("FOO-BAR".to_string(), to_cobol_case("fooBar"));
+        assert_eq!("FOO-BAR".to_string(), to_cobol_case("foo-bar"));
+        assert_eq!("FOO1".to_string(), to_cobol_case("foo1"));
+    }
+}

--- a/tests/snapshots/integration__spec_test__spec_cmd_omitted_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_omitted_help.snap
@@ -2,7 +2,6 @@
 source: tests/spec_test.rs
 assertion_line: 13
 expression: output
-
 ---
 RUN
 spec cmd-omitted -h
@@ -15,14 +14,14 @@ spec-cmd-omitted
 Omitted
 
 USAGE:
-    spec cmd-omitted [OPTIONS] [ARG-1]
+    spec cmd-omitted [OPTIONS] [ARG1]
 
 ARGS:
-    <ARG-1>    
+    <ARG1>    
 
 OPTIONS:
-        --flag1           
-    -h, --help            Print help information
-        --opt1 <OPT-1>    
+        --flag1          
+    -h, --help           Print help information
+        --opt1 <OPT1>    
 
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_formats_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_formats_help.snap
@@ -2,7 +2,6 @@
 source: tests/spec_test.rs
 assertion_line: 23
 expression: output
-
 ---
 RUN
 spec cmd-option-formats -h
@@ -18,13 +17,13 @@ USAGE:
     spec cmd-option-formats [OPTIONS]
 
 OPTIONS:
-    -a, --opt2 <OPT-2>    
-    -b, --opt5 <OPT-5>    With description
-    -c, --opt6 <OPT>      
-    -h, --help            Print help information
-        --opt1 <OPT-1>    
-        --opt3 <OPT>      
-        --opt4 <OPT-4>    With description
-        --opt7 <OPT>      With description
+    -a, --opt2 <OPT2>    
+    -b, --opt5 <OPT5>    With description
+    -c, --opt6 <OPT>     
+    -h, --help           Print help information
+        --opt1 <OPT1>    
+        --opt3 <OPT>     
+        --opt4 <OPT4>    With description
+        --opt7 <OPT>     With description
 
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec.snap
@@ -2,19 +2,18 @@
 source: tests/spec_test.rs
 assertion_line: 68
 expression: output
-
 ---
 RUN
 spec cmd-option-names --opt2 value2 --opt3 value3_0,value3_1 --opt4 value4_0 --opt4 value4_1 --opt6 a --opt8 a
 
 STDOUT
-argc_opt_2=value2
-argc_opt_3=( value3_0 value3_1 )
-argc_opt_4=( value4_0 value4_1 )
-argc_opt_5=a
-argc_opt_6=a
-argc_opt_7=a
-argc_opt_8=a
+argc_opt2=value2
+argc_opt3=( value3_0 value3_1 )
+argc_opt4=( value4_0 value4_1 )
+argc_opt5=a
+argc_opt6=a
+argc_opt7=a
+argc_opt8=a
 argc__call=cmd_option_names
 
 STDERR

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec_eval.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec_eval.snap
@@ -2,19 +2,18 @@
 source: tests/spec_test.rs
 assertion_line: 91
 expression: output
-
 ---
 RUN
 spec cmd-option-names --opt2 value2 --opt3 value3_0,value3_1 --opt4 value4_0 --opt4 value4_1 --opt6 a --opt8 a
 
 STDOUT
-argc_opt_2=value2
-argc_opt_3=( value3_0 value3_1 )
-argc_opt_4=( value4_0 value4_1 )
-argc_opt_5=a
-argc_opt_6=a
-argc_opt_7=a
-argc_opt_8=a
+argc_opt2=value2
+argc_opt3=( value3_0 value3_1 )
+argc_opt4=( value4_0 value4_1 )
+argc_opt5=a
+argc_opt6=a
+argc_opt7=a
+argc_opt8=a
 cmd_option_names
 
 STDERR

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_names_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_names_help.snap
@@ -2,7 +2,6 @@
 source: tests/spec_test.rs
 assertion_line: 18
 expression: output
-
 ---
 RUN
 spec cmd-option-names -h
@@ -15,17 +14,17 @@ spec-cmd-option-names
 Options all kind of names
 
 USAGE:
-    spec cmd-option-names [OPTIONS] --opt2 <OPT-2> --opt4 <OPT-4>... --opt8 <OPT-8>
+    spec cmd-option-names [OPTIONS] --opt2 <OPT2> --opt4 <OPT4>... --opt8 <OPT8>
 
 OPTIONS:
-    -h, --help               Print help information
-        --opt1 <OPT-1>       optional
-        --opt2 <OPT-2>       required
-        --opt3 <OPT-3>...    optional, multiple
-        --opt4 <OPT-4>...    required, multiple
-        --opt5 <OPT-5>       optional, default [default: a]
-        --opt6 <OPT-6>       choices [possible values: a, b, c]
-        --opt7 <OPT-7>       choices, default [default: a] [possible values: a, b, c]
-        --opt8 <OPT-8>       required, choices [possible values: a, b, c]
+    -h, --help              Print help information
+        --opt1 <OPT1>       optional
+        --opt2 <OPT2>       required
+        --opt3 <OPT3>...    optional, multiple
+        --opt4 <OPT4>...    required, multiple
+        --opt5 <OPT5>       optional, default [default: a]
+        --opt6 <OPT6>       choices [possible values: a, b, c]
+        --opt7 <OPT7>       choices, default [default: a] [possible values: a, b, c]
+        --opt8 <OPT8>       required, choices [possible values: a, b, c]
 
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_quotes_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_quotes_help.snap
@@ -2,7 +2,6 @@
 source: tests/spec_test.rs
 assertion_line: 31
 expression: output
-
 ---
 RUN
 spec cmd-option-quotes -h
@@ -18,11 +17,11 @@ USAGE:
     spec cmd-option-quotes [OPTIONS]
 
 OPTIONS:
-    -h, --help            Print help information
-        --opt1 <OPT-1>    [default: a]
-        --opt2 <OPT-2>    [default: "a b"]
-        --opt3 <OPT-3>    [possible values: "a 3", b, c]
-        --opt4 <OPT-4>    [default: "a b"] [possible values: "a b", "c d", "e f"]
-        --opt5 <OPT-5>    [default: a|b] [possible values: a|b, c]d, ef]
+    -h, --help           Print help information
+        --opt1 <OPT1>    [default: a]
+        --opt2 <OPT2>    [default: "a b"]
+        --opt3 <OPT3>    [possible values: "a 3", b, c]
+        --opt4 <OPT4>    [default: "a b"] [possible values: "a b", "c d", "e f"]
+        --opt5 <OPT5>    [default: a|b] [possible values: a|b, c]d, ef]
 
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_only_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_only_help.snap
@@ -2,7 +2,6 @@
 source: tests/spec_test.rs
 assertion_line: 44
 expression: output
-
 ---
 RUN
 spec cmd-positional-only -h
@@ -15,10 +14,10 @@ spec-cmd-positional-only
 Positional one required
 
 USAGE:
-    spec cmd-positional-only <ARG-1>
+    spec cmd-positional-only <ARG1>
 
 ARGS:
-    <ARG-1>    A required arg
+    <ARG1>    A required arg
 
 OPTIONS:
     -h, --help    Print help information

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_requires_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_requires_help.snap
@@ -2,7 +2,6 @@
 source: tests/spec_test.rs
 assertion_line: 52
 expression: output
-
 ---
 RUN
 spec cmd-positional-requires -h
@@ -15,11 +14,11 @@ spec-cmd-positional-requires
 Positional all required
 
 USAGE:
-    spec cmd-positional-requires <ARG-1> <ARG-2>...
+    spec cmd-positional-requires <ARG1> <ARG2>...
 
 ARGS:
-    <ARG-1>       A required arg
-    <ARG-2>...    A required arg, multiple
+    <ARG1>       A required arg
+    <ARG2>...    A required arg, multiple
 
 OPTIONS:
     -h, --help    Print help information

--- a/tests/snapshots/integration__spec_test__spec_cmd_preferred_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_preferred_exec.snap
@@ -2,15 +2,14 @@
 source: tests/spec_test.rs
 assertion_line: 60
 expression: output
-
 ---
 RUN
 spec cmd-preferred -f -o A AB C D
 
 STDOUT
-argc_arg_1=( AB C\ D )
-argc_flag_1=1
-argc_opt_1=A
+argc_arg1=( AB C\ D )
+argc_flag1=1
+argc_opt1=A
 argc__call=cmd_preferred
 
 STDERR

--- a/tests/snapshots/integration__spec_test__spec_cmd_preferred_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_preferred_help.snap
@@ -2,7 +2,6 @@
 source: tests/spec_test.rs
 assertion_line: 8
 expression: output
-
 ---
 RUN
 spec cmd-preferred -h
@@ -15,14 +14,14 @@ spec-cmd-preferred
 Preferred
 
 USAGE:
-    spec cmd-preferred [OPTIONS] [ARG-1]...
+    spec cmd-preferred [OPTIONS] [ARG1]...
 
 ARGS:
-    <ARG-1>...    A positional arg
+    <ARG1>...    A positional arg
 
 OPTIONS:
-    -f, --flag1           A flag
-    -h, --help            Print help information
-    -o, --opt1 <OPT-1>    A option
+    -f, --flag1          A flag
+    -h, --help           Print help information
+    -o, --opt1 <OPT1>    A option
 
 


### PR DESCRIPTION
In prev version, changing case for names:
```
value name: --opt1 => OPT_1
variable name: --opt1 => argc_opt_1
cmd name: cmd1 => cmd_1
```

In this version, changing case for names:
```
value name: --opt1 => OPT1
variable name: --opt1 => argc_opt1
cmd name: cmd1 => cmd1
```