### PR TITLE
feat: add default postional arg

### DIFF
--- a/tests/snapshots/integration__spec_test__spec_cmd_option_names_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_names_help.snap
@@ -14,7 +14,7 @@ spec-cmd-option-names
 Options all kind of names
 
 USAGE:
-    spec cmd-option-names [OPTIONS] --opt2 <OPT2> --opt4 <OPT4>... --opt8 <OPT8>
+    spec cmd-option-names [OPTIONS] --opt2 <OPT2> --opt4 <OPT4>... --opt8 <OPT8> [--]
 
 OPTIONS:
     -h, --help              Print help information

--- a/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg_exec.snap
@@ -1,0 +1,15 @@
+---
+source: tests/spec_test.rs
+assertion_line: 197
+expression: output
+---
+RUN
+spec cmd-without-any-arg foo bar
+
+STDOUT
+argc__args=( foo bar )
+argc__call=cmd_without_any_arg
+
+STDERR
+
+

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -191,3 +191,11 @@ fn test_spec_cmd_alias() {
 fn test_spec_cmd_without_any_arg() {
     snapshot!(include_str!("spec.sh"), &["spec", "cmd-without-any-arg"],);
 }
+
+#[test]
+fn test_spec_cmd_without_any_arg_exec() {
+    snapshot!(
+        include_str!("spec.sh"),
+        &["spec", "cmd-without-any-arg", "foo", "bar"],
+    );
+}


### PR DESCRIPTION
In previous version, argc do not allow positional arguments if subcommand has no @arg tag.

Create a demo.sh
```sh
cmd() {
  echo ${argc__args[@]}
  :;
}

eval "$(argc -e $0 "$@")"
```

Run it

```

$ bash demo.sh cmd foo
error: Found argument 'a' which wasn't expected, or isn't valid in this context

USAGE:
    demo cmd

For more information try --help

```

After this pr merged, A default postional arg is implicitly added.
Argc can collect postional args and put it into `$argc__args` variable.

```
$ bash demo.sh cmd foo bar
foo bar

$ argc -e demo.sh cmd foo bar
argc__args=( foo bar )
cmd
```