### PR TITLE
feat: no need to explicitly pass `-e` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To write a command line program with Argc, we only need to do two things:
 2. Call the following command to entrust Argc to process command line parameters for us
 
 ```sh
-eval "$(argc -e $0 "$@")"
+eval "$(argc $0 "$@")"
 ```
 
 Argc will do the following for us:

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -20,4 +20,4 @@ download() {
     echo "arg:    target            $argc_target"
 }
 
-eval "$(argc -e $0 "$@")"
+eval "$(argc $0 "$@")"

--- a/examples/options.sh
+++ b/examples/options.sh
@@ -8,7 +8,7 @@
 # @option      -y --opt7[=x|y|z]   A option with choices and default value
 # @option      -z --opt8![x|y|z]   A required option with choices
 
-eval "$(argc -e $0 "$@")"
+eval "$(argc $0 "$@")"
 
 
 ( set -o posix ; set ) | grep argc_ # print variables with argc_ prefix

--- a/examples/subcmds.sh
+++ b/examples/subcmds.sh
@@ -49,6 +49,6 @@ cmd8() {
 }
 
 
-eval "$(argc -e $0 "$@")"
+eval "$(argc $0 "$@")"
 
 ( set -o posix ; set ) | grep argc_ # print variables with argc_ prefix

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -3,10 +3,8 @@ macro_rules! snapshot {
     (
         $source:expr,
         $args:expr,
-        $(eval: $eval:expr,)?
     ) => {
         let runner = argc::Runner::new($source);
-        $(let runner = runner.set_eval($eval);)?
         let (stdout, stderr) = match runner.run($args).unwrap() {
             Ok(stdout) => (stdout, String::new()),
             Err(stderr) => (String::new(), stderr),

--- a/tests/mainfn_test.rs
+++ b/tests/mainfn_test.rs
@@ -15,7 +15,7 @@ main() {
 
 }
     "###;
-    plain!(script, &["prog"], stdout: "argc__call=main",);
+    plain!(script, &["prog"], stdout: "main",);
 }
 
 #[test]
@@ -32,7 +32,7 @@ main() {
 
 }
     "###;
-    plain!(script, &["prog", "cmd"], stdout: "argc__call=cmd",);
+    plain!(script, &["prog", "cmd"], stdout: "cmd",);
     snapshot!(script, &["prog", "-h"],);
 }
 
@@ -47,7 +47,7 @@ cmd() {
 }
 
     "###;
-    plain!(script, &["prog", "cmd"], stdout: "argc__call=cmd",);
+    plain!(script, &["prog", "cmd"], stdout: "cmd",);
     snapshot!(script, &["prog"],);
 }
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_alias.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_alias.snap
@@ -1,14 +1,13 @@
 ---
 source: tests/spec_test.rs
-assertion_line: 151
+assertion_line: 186
 expression: output
-
 ---
 RUN
 spec alias
 
 STDOUT
-argc__call=cmd_alias
+cmd_alias
 
 STDERR
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec.snap
@@ -14,7 +14,7 @@ argc_opt5=a
 argc_opt6=a
 argc_opt7=a
 argc_opt8=a
-argc__call=cmd_option_names
+cmd_option_names
 
 STDERR
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_default_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_default_exec.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec_test.rs
-assertion_line: 163
+assertion_line: 162
 expression: output
 ---
 RUN
@@ -8,8 +8,7 @@ spec cmd-positional-with-choices-and-default
 
 STDOUT
 argc_arg=a
-argc__call=cmd_positional_with_choices_and_default
-argc__call_args=( a )
+cmd_positional_with_choices_and_default a
 
 STDERR
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_exec.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec_test.rs
-assertion_line: 139
+assertion_line: 138
 expression: output
 ---
 RUN
@@ -8,8 +8,7 @@ spec cmd-positional-with-choices a
 
 STDOUT
 argc_arg=a
-argc__call=cmd_positional_with_choices
-argc__call_args=( a )
+cmd_positional_with_choices a
 
 STDERR
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_default_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_default_exec.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec_test.rs
-assertion_line: 123
+assertion_line: 122
 expression: output
 ---
 RUN
@@ -8,8 +8,7 @@ spec cmd-positional-with-default
 
 STDOUT
 argc_arg=a
-argc__call=cmd_positional_with_default
-argc__call_args=( a )
+cmd_positional_with_default a
 
 STDERR
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_preferred_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_preferred_exec.snap
@@ -10,8 +10,7 @@ STDOUT
 argc_arg1=( AB C\ D )
 argc_flag1=1
 argc_opt1=A
-argc__call=cmd_preferred
-argc__call_args=( AB C\ D )
+cmd_preferred AB C\ D
 
 STDERR
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg.snap
@@ -1,14 +1,13 @@
 ---
 source: tests/spec_test.rs
-assertion_line: 156
+assertion_line: 191
 expression: output
-
 ---
 RUN
 spec cmd-without-any-arg
 
 STDOUT
-argc__call=cmd_without_any_arg
+cmd_without_any_arg
 
 STDERR
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg_exec.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/spec_test.rs
-assertion_line: 197
+assertion_line: 196
 expression: output
 ---
 RUN
@@ -8,8 +8,7 @@ spec cmd-without-any-arg foo bar
 
 STDOUT
 argc__args=( foo bar )
-argc__call=cmd_without_any_arg
-argc__call_args=( foo bar )
+cmd_without_any_arg foo bar
 
 STDERR
 

--- a/tests/spec.sh
+++ b/tests/spec.sh
@@ -113,4 +113,4 @@ print_argc_vars() {
     ( set -o posix ; set ) | grep argc_
 }
 
-eval $(target/debug/argc -e $0 "$@")
+eval $(target/debug/argc $0 "$@")

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -106,7 +106,6 @@ fn test_spec_cmd_option_names_exec_eval() {
             "--opt8",
             "a",
         ],
-        eval: true,
     );
 }
 
@@ -205,6 +204,5 @@ fn test_spec_cmd_without_any_arg_exec_eval() {
     snapshot!(
         include_str!("spec.sh"),
         &["spec", "cmd-without-any-arg", "foo", "bar"],
-        eval: true,
     );
 }


### PR DESCRIPTION
After this pr merged, no need to explicitly pass `-e` option to argc.

```sh
eval "$(argc $0 "$@")"
```
is exactly equivalent to
```sh
eval "$(argc -e $0 "$@")"
```

Now `-e` option will be hidden from help message.

when v1.0 is out, `-e` option will be removed.