### PR TITLE
feat: less constrained on cmd name

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,18 +1,5 @@
 use convert_case::{Boundary, Converter, Pattern};
 
-/// Transform into a lower cased string with dashes between words. `foo_bar` => `foo-bar`
-pub fn to_kebab_case(value: &str) -> String {
-    Converter::new()
-        .set_pattern(Pattern::Lowercase)
-        .set_delim("-")
-        .set_boundaries(&[
-            Boundary::Underscore,
-            Boundary::LowerUpper,
-            Boundary::Underscore,
-        ])
-        .convert(value)
-}
-
 /// Transform into upper case string with an underscore between words. `foo-bar` => `FOO-BAR`
 pub fn to_cobol_case(value: &str) -> String {
     Converter::new()
@@ -53,13 +40,6 @@ pub fn is_default_value_terminate(c: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_kebab() {
-        assert_eq!("foo-bar".to_string(), to_kebab_case("fooBar"));
-        assert_eq!("foo-bar".to_string(), to_kebab_case("foo_bar"));
-        assert_eq!("foo1".to_string(), to_kebab_case("foo1"));
-    }
 
     #[test]
     fn test_cobol() {

--- a/tests/snapshots/integration__spec_test__spec_cmd_flag_formats_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_flag_formats_help.snap
@@ -4,17 +4,17 @@ assertion_line: 39
 expression: output
 ---
 RUN
-spec cmd-flag-formats -h
+spec cmd_flag_formats -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-flag-formats 
+spec-cmd_flag_formats 
 All kind of flags
 
 USAGE:
-    spec cmd-flag-formats [OPTIONS]
+    spec cmd_flag_formats [OPTIONS]
 
 OPTIONS:
     -a, --foo2    

--- a/tests/snapshots/integration__spec_test__spec_cmd_omitted_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_omitted_help.snap
@@ -4,17 +4,17 @@ assertion_line: 13
 expression: output
 ---
 RUN
-spec cmd-omitted -h
+spec cmd_omitted -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-omitted 
+spec-cmd_omitted 
 Omitted
 
 USAGE:
-    spec cmd-omitted [OPTIONS] [ARG1]
+    spec cmd_omitted [OPTIONS] [ARG1]
 
 ARGS:
     <ARG1>    

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_formats_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_formats_help.snap
@@ -4,17 +4,17 @@ assertion_line: 23
 expression: output
 ---
 RUN
-spec cmd-option-formats -h
+spec cmd_option_formats -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-option-formats 
+spec-cmd_option_formats 
 Options all kind of formats
 
 USAGE:
-    spec cmd-option-formats [OPTIONS]
+    spec cmd_option_formats [OPTIONS]
 
 OPTIONS:
     -a, --opt2 <OPT2>    

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec.snap
@@ -4,7 +4,7 @@ assertion_line: 68
 expression: output
 ---
 RUN
-spec cmd-option-names --opt2 value2 --opt3 value3_0,value3_1 --opt4 value4_0 --opt4 value4_1 --opt6 a --opt8 a
+spec cmd_option_names --opt2 value2 --opt3 value3_0,value3_1 --opt4 value4_0 --opt4 value4_1 --opt6 a --opt8 a
 
 STDOUT
 argc_opt2=value2

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec_eval.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_names_exec_eval.snap
@@ -4,7 +4,7 @@ assertion_line: 91
 expression: output
 ---
 RUN
-spec cmd-option-names --opt2 value2 --opt3 value3_0,value3_1 --opt4 value4_0 --opt4 value4_1 --opt6 a --opt8 a
+spec cmd_option_names --opt2 value2 --opt3 value3_0,value3_1 --opt4 value4_0 --opt4 value4_1 --opt6 a --opt8 a
 
 STDOUT
 argc_opt2=value2

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_names_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_names_help.snap
@@ -4,17 +4,17 @@ assertion_line: 18
 expression: output
 ---
 RUN
-spec cmd-option-names -h
+spec cmd_option_names -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-option-names 
+spec-cmd_option_names 
 Options all kind of names
 
 USAGE:
-    spec cmd-option-names [OPTIONS] --opt2 <OPT2> --opt4 <OPT4>... --opt8 <OPT8> [--]
+    spec cmd_option_names [OPTIONS] --opt2 <OPT2> --opt4 <OPT4>... --opt8 <OPT8> [--]
 
 OPTIONS:
     -h, --help              Print help information

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_quotes_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_quotes_help.snap
@@ -4,17 +4,17 @@ assertion_line: 31
 expression: output
 ---
 RUN
-spec cmd-option-quotes -h
+spec cmd_option_quotes -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-option-quotes 
+spec-cmd_option_quotes 
 Option value quoted
 
 USAGE:
-    spec cmd-option-quotes [OPTIONS]
+    spec cmd_option_quotes [OPTIONS]
 
 OPTIONS:
     -h, --help           Print help information

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_only_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_only_help.snap
@@ -4,17 +4,17 @@ assertion_line: 44
 expression: output
 ---
 RUN
-spec cmd-positional-only -h
+spec cmd_positional_only -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-positional-only 
+spec-cmd_positional_only 
 Positional one required
 
 USAGE:
-    spec cmd-positional-only <ARG1>
+    spec cmd_positional_only <ARG1>
 
 ARGS:
     <ARG1>    A required arg

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_requires_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_requires_help.snap
@@ -4,17 +4,17 @@ assertion_line: 52
 expression: output
 ---
 RUN
-spec cmd-positional-requires -h
+spec cmd_positional_requires -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-positional-requires 
+spec-cmd_positional_requires 
 Positional all required
 
 USAGE:
-    spec cmd-positional-requires <ARG1> <ARG2>...
+    spec cmd_positional_requires <ARG1> <ARG2>...
 
 ARGS:
     <ARG1>       A required arg

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices.snap
@@ -4,17 +4,17 @@ assertion_line: 130
 expression: output
 ---
 RUN
-spec cmd-positional-with-choices -h
+spec cmd_positional_with_choices -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-positional-with-choices 
+spec-cmd_positional_with_choices 
 Positional with choices
 
 USAGE:
-    spec cmd-positional-with-choices [ARG]
+    spec cmd_positional_with_choices [ARG]
 
 ARGS:
     <ARG>    A arg with choices [possible values: a, b]

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_default.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_default.snap
@@ -4,17 +4,17 @@ assertion_line: 154
 expression: output
 ---
 RUN
-spec cmd-positional-with-choices-and-default -h
+spec cmd_positional_with_choices_and_default -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-positional-with-choices-and-default 
+spec-cmd_positional_with_choices_and_default 
 Positional with choices and value
 
 USAGE:
-    spec cmd-positional-with-choices-and-default [ARG]
+    spec cmd_positional_with_choices_and_default [ARG]
 
 ARGS:
     <ARG>    A arg with choices and default value [default: a] [possible values: a, b]

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_default_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_default_exec.snap
@@ -4,7 +4,7 @@ assertion_line: 162
 expression: output
 ---
 RUN
-spec cmd-positional-with-choices-and-default
+spec cmd_positional_with_choices_and_default
 
 STDOUT
 argc_arg=a

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_required.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_required.snap
@@ -4,17 +4,17 @@ assertion_line: 170
 expression: output
 ---
 RUN
-spec cmd-positional-with-choices-and-required -h
+spec cmd_positional_with_choices_and_required -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-positional-with-choices-and-required 
+spec-cmd_positional_with_choices_and_required 
 Positional with choices and required
 
 USAGE:
-    spec cmd-positional-with-choices-and-required <ARG>
+    spec cmd_positional_with_choices_and_required <ARG>
 
 ARGS:
     <ARG>    A arg with choices and required [possible values: a, b]

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_required_exec_fail.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_and_required_exec_fail.snap
@@ -4,7 +4,7 @@ assertion_line: 178
 expression: output
 ---
 RUN
-spec cmd-positional-with-choices-and-required
+spec cmd_positional_with_choices_and_required
 
 STDOUT
 
@@ -14,7 +14,7 @@ error: The following required arguments were not provided:
     <ARG>
 
 USAGE:
-    spec cmd-positional-with-choices-and-required <ARG>
+    spec cmd_positional_with_choices_and_required <ARG>
 
 For more information try --help
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_exec.snap
@@ -4,7 +4,7 @@ assertion_line: 138
 expression: output
 ---
 RUN
-spec cmd-positional-with-choices a
+spec cmd_positional_with_choices a
 
 STDOUT
 argc_arg=a

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_exec_fail.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_exec_fail.snap
@@ -4,7 +4,7 @@ assertion_line: 146
 expression: output
 ---
 RUN
-spec cmd-positional-with-choices x
+spec cmd_positional_with_choices x
 
 STDOUT
 
@@ -14,7 +14,7 @@ error: "x" isn't a valid value for '<ARG>'
 	[possible values: a, b]
 
 USAGE:
-    spec cmd-positional-with-choices <ARG>
+    spec cmd_positional_with_choices <ARG>
 
 For more information try --help
 

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_default.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_default.snap
@@ -4,17 +4,17 @@ assertion_line: 114
 expression: output
 ---
 RUN
-spec cmd-positional-with-default -h
+spec cmd_positional_with_default -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-positional-with-default 
+spec-cmd_positional_with_default 
 Positional with default value
 
 USAGE:
-    spec cmd-positional-with-default [ARG]
+    spec cmd_positional_with_default [ARG]
 
 ARGS:
     <ARG>    A arg with default value [default: a]

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_default_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_default_exec.snap
@@ -4,7 +4,7 @@ assertion_line: 122
 expression: output
 ---
 RUN
-spec cmd-positional-with-default
+spec cmd_positional_with_default
 
 STDOUT
 argc_arg=a

--- a/tests/snapshots/integration__spec_test__spec_cmd_preferred_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_preferred_exec.snap
@@ -4,7 +4,7 @@ assertion_line: 60
 expression: output
 ---
 RUN
-spec cmd-preferred -f -o A AB C D
+spec cmd_preferred -f -o A AB C D
 
 STDOUT
 argc_arg1=( AB C\ D )

--- a/tests/snapshots/integration__spec_test__spec_cmd_preferred_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_preferred_help.snap
@@ -4,17 +4,17 @@ assertion_line: 8
 expression: output
 ---
 RUN
-spec cmd-preferred -h
+spec cmd_preferred -h
 
 STDOUT
 
 
 STDERR
-spec-cmd-preferred 
+spec-cmd_preferred 
 Preferred
 
 USAGE:
-    spec cmd-preferred [OPTIONS] [ARG1]...
+    spec cmd_preferred [OPTIONS] [ARG1]...
 
 ARGS:
     <ARG1>...    A positional arg

--- a/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg.snap
@@ -4,7 +4,7 @@ assertion_line: 191
 expression: output
 ---
 RUN
-spec cmd-without-any-arg
+spec cmd_without_any_arg
 
 STDOUT
 cmd_without_any_arg

--- a/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg_exec.snap
@@ -4,7 +4,7 @@ assertion_line: 196
 expression: output
 ---
 RUN
-spec cmd-without-any-arg foo bar
+spec cmd_without_any_arg foo bar
 
 STDOUT
 argc__args=( foo bar )

--- a/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg_exec_eval.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_without_any_arg_exec_eval.snap
@@ -4,7 +4,7 @@ assertion_line: 204
 expression: output
 ---
 RUN
-spec cmd-without-any-arg foo bar
+spec cmd_without_any_arg foo bar
 
 STDOUT
 argc__args=( foo bar )

--- a/tests/snapshots/integration__spec_test__spec_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_help.snap
@@ -22,33 +22,33 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    cmd-alias
+    cmd_alias
             Command with alias [aliases: a, alias]
-    cmd-flag-formats
+    cmd_flag_formats
             All kind of flags
-    cmd-omitted
+    cmd_omitted
             Omitted
-    cmd-option-formats
+    cmd_option_formats
             Options all kind of formats
-    cmd-option-names
+    cmd_option_names
             Options all kind of names
-    cmd-option-quotes
+    cmd_option_quotes
             Option value quoted
-    cmd-positional-only
+    cmd_positional_only
             Positional one required
-    cmd-positional-requires
+    cmd_positional_requires
             Positional all required
-    cmd-positional-with-choices
+    cmd_positional_with_choices
             Positional with choices
-    cmd-positional-with-choices-and-default
+    cmd_positional_with_choices_and_default
             Positional with choices and value
-    cmd-positional-with-choices-and-required
+    cmd_positional_with_choices_and_required
             Positional with choices and required
-    cmd-positional-with-default
+    cmd_positional_with_default
             Positional with default value
-    cmd-preferred
+    cmd_preferred
             Preferred
-    cmd-without-any-arg
+    cmd_without_any_arg
             Command without any arg
     help
             Print this message or the help of the given subcommand(s)

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -5,24 +5,24 @@ fn test_spec_help() {
 
 #[test]
 fn test_spec_cmd_preferred_help() {
-    snapshot!(include_str!("spec.sh"), &["spec", "cmd-preferred", "-h"],);
+    snapshot!(include_str!("spec.sh"), &["spec", "cmd_preferred", "-h"],);
 }
 
 #[test]
 fn test_spec_cmd_omitted_help() {
-    snapshot!(include_str!("spec.sh"), &["spec", "cmd-omitted", "-h"],);
+    snapshot!(include_str!("spec.sh"), &["spec", "cmd_omitted", "-h"],);
 }
 
 #[test]
 fn test_spec_cmd_option_names_help() {
-    snapshot!(include_str!("spec.sh"), &["spec", "cmd-option-names", "-h"],);
+    snapshot!(include_str!("spec.sh"), &["spec", "cmd_option_names", "-h"],);
 }
 
 #[test]
 fn test_spec_cmd_option_formats_help() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-option-formats", "-h"],
+        &["spec", "cmd_option_formats", "-h"],
     );
 }
 
@@ -30,20 +30,20 @@ fn test_spec_cmd_option_formats_help() {
 fn test_spec_cmd_option_quotes_help() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-option-quotes", "-h"],
+        &["spec", "cmd_option_quotes", "-h"],
     );
 }
 
 #[test]
 fn test_spec_cmd_flag_formats_help() {
-    snapshot!(include_str!("spec.sh"), &["spec", "cmd-flag-formats", "-h"],);
+    snapshot!(include_str!("spec.sh"), &["spec", "cmd_flag_formats", "-h"],);
 }
 
 #[test]
 fn test_spec_cmd_positional_only_help() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-only", "-h"],
+        &["spec", "cmd_positional_only", "-h"],
     );
 }
 
@@ -51,7 +51,7 @@ fn test_spec_cmd_positional_only_help() {
 fn test_spec_cmd_positional_requires_help() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-requires", "-h"],
+        &["spec", "cmd_positional_requires", "-h"],
     );
 }
 
@@ -59,7 +59,7 @@ fn test_spec_cmd_positional_requires_help() {
 fn test_spec_cmd_preferred_exec() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-preferred", "-f", "-o", "A", "AB", "C D"],
+        &["spec", "cmd_preferred", "-f", "-o", "A", "AB", "C D"],
     );
 }
 
@@ -69,7 +69,7 @@ fn test_spec_cmd_option_names_exec() {
         include_str!("spec.sh"),
         &[
             "spec",
-            "cmd-option-names",
+            "cmd_option_names",
             "--opt2",
             "value2",
             "--opt3",
@@ -92,7 +92,7 @@ fn test_spec_cmd_option_names_exec_eval() {
         include_str!("spec.sh"),
         &[
             "spec",
-            "cmd-option-names",
+            "cmd_option_names",
             "--opt2",
             "value2",
             "--opt3",
@@ -113,7 +113,7 @@ fn test_spec_cmd_option_names_exec_eval() {
 fn test_spec_cmd_positional_with_default() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-with-default", "-h"],
+        &["spec", "cmd_positional_with_default", "-h"],
     );
 }
 
@@ -121,7 +121,7 @@ fn test_spec_cmd_positional_with_default() {
 fn test_spec_cmd_positional_with_default_exec() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-with-default"],
+        &["spec", "cmd_positional_with_default"],
     );
 }
 
@@ -129,7 +129,7 @@ fn test_spec_cmd_positional_with_default_exec() {
 fn test_spec_cmd_positional_with_choices() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-with-choices", "-h"],
+        &["spec", "cmd_positional_with_choices", "-h"],
     );
 }
 
@@ -137,7 +137,7 @@ fn test_spec_cmd_positional_with_choices() {
 fn test_spec_cmd_positional_with_choices_exec() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-with-choices", "a"],
+        &["spec", "cmd_positional_with_choices", "a"],
     );
 }
 
@@ -145,7 +145,7 @@ fn test_spec_cmd_positional_with_choices_exec() {
 fn test_spec_cmd_positional_with_choices_exec_fail() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-with-choices", "x"],
+        &["spec", "cmd_positional_with_choices", "x"],
     );
 }
 
@@ -153,7 +153,7 @@ fn test_spec_cmd_positional_with_choices_exec_fail() {
 fn test_spec_cmd_positional_with_choices_and_default() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-with-choices-and-default", "-h"],
+        &["spec", "cmd_positional_with_choices_and_default", "-h"],
     );
 }
 
@@ -161,7 +161,7 @@ fn test_spec_cmd_positional_with_choices_and_default() {
 fn test_spec_cmd_positional_with_choices_and_default_exec() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-with-choices-and-default"],
+        &["spec", "cmd_positional_with_choices_and_default"],
     );
 }
 
@@ -169,7 +169,7 @@ fn test_spec_cmd_positional_with_choices_and_default_exec() {
 fn test_spec_cmd_positional_with_choices_and_required() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-with-choices-and-required", "-h"],
+        &["spec", "cmd_positional_with_choices_and_required", "-h"],
     );
 }
 
@@ -177,7 +177,7 @@ fn test_spec_cmd_positional_with_choices_and_required() {
 fn test_spec_cmd_positional_with_choices_and_required_exec_fail() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-positional-with-choices-and-required"],
+        &["spec", "cmd_positional_with_choices_and_required"],
     );
 }
 
@@ -188,14 +188,14 @@ fn test_spec_cmd_alias() {
 
 #[test]
 fn test_spec_cmd_without_any_arg() {
-    snapshot!(include_str!("spec.sh"), &["spec", "cmd-without-any-arg"],);
+    snapshot!(include_str!("spec.sh"), &["spec", "cmd_without_any_arg"],);
 }
 
 #[test]
 fn test_spec_cmd_without_any_arg_exec() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-without-any-arg", "foo", "bar"],
+        &["spec", "cmd_without_any_arg", "foo", "bar"],
     );
 }
 
@@ -203,6 +203,6 @@ fn test_spec_cmd_without_any_arg_exec() {
 fn test_spec_cmd_without_any_arg_exec_eval() {
     snapshot!(
         include_str!("spec.sh"),
-        &["spec", "cmd-without-any-arg", "foo", "bar"],
+        &["spec", "cmd_without_any_arg", "foo", "bar"],
     );
 }


### PR DESCRIPTION
cmd/fn name can contain many other characters besides `[A-Za-z0-9_-]`
```sh
# @cmd
foo_bar() {
    echo "foo_bar"
}
# @cmd
foo-bar() {
    echo "foo-bar"
}
# @cmd
foo.bar() {
    echo "foo.bar"
}
# @cmd
foo@bar() {
    echo "foo@bar"
}
# @cmd
foo:bar() {
    echo "foo:bar"
}

eval "$(argc $0 "$@")"
```