### PR TITLE
feat: allow custom help subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Argc generates parsing rules and help documentation based on tags (fields marked
  - [@describe](#describe)
  - [@version](#version)
  - [@author](#author)
+ - [@help](#help)
  - [@cmd](#cmd)
  - [@alias](#alias)
  - [@option](#option)
@@ -87,6 +88,19 @@ Define version
 ```
 
 Define author
+
+### @help
+
+```sh
+@help [false|string]
+
+# @help false   
+# @help Print help information
+```
+Customize help subcommand.
+
+1. disable help subcommand with `# @help false`
+2. custom help subcommand message with `# @help Print help information`
 
 ### @cmd
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,7 @@ struct RootData<'a> {
     author: Option<&'a str>,
     version: Option<&'a str>,
     names: HashMap<&'a str, Position>,
+    help: Option<&'a str>,
     main: bool,
 }
 
@@ -88,6 +89,11 @@ impl<'a> Cmd<'a> {
                 EventData::Author(value) => {
                     if is_root_scope {
                         root_data.author = Some(*value);
+                    }
+                }
+                EventData::Help(value) => {
+                    if is_root_scope {
+                        root_data.help = Some(*value);
                     }
                 }
                 EventData::Cmd(value) => {
@@ -185,6 +191,13 @@ impl<'a> Cmd<'a> {
             }
             if !self.subcommands.is_empty() && !root_data.main {
                 cmd = cmd.subcommand_required(true).arg_required_else_help(true);
+            }
+            if let Some(help) = root_data.help {
+                if help == "false" {
+                    cmd = cmd.disable_help_subcommand(true);
+                } else {
+                    cmd = cmd.subcommand(Command::new("help").about(help))
+                }
             }
         }
         if !self.aliases.is_empty() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -29,6 +29,8 @@ pub enum EventData<'a> {
     Version(&'a str),
     /// Author info
     Author(&'a str),
+    /// Help subcommand
+    Help(&'a str),
     /// Define a subcommand, e.g. `@cmd A sub command`
     Cmd(&'a str),
     /// Define alias for a subcommand, e.g. `@alias t,tst`
@@ -106,13 +108,20 @@ fn parse_tag(input: &str) -> nom::IResult<&str, Option<EventData>> {
 fn parse_tag_text(input: &str) -> nom::IResult<&str, Option<EventData>> {
     map(
         pair(
-            alt((tag("describe"), tag("version"), tag("author"), tag("cmd"))),
+            alt((
+                tag("describe"),
+                tag("version"),
+                tag("author"),
+                tag("cmd"),
+                tag("help"),
+            )),
             parse_tail,
         ),
         |(tag, text)| {
             Some(match tag {
                 "describe" => EventData::Describe(text),
                 "version" => EventData::Version(text),
+                "help" => EventData::Help(text),
                 "author" => EventData::Author(text),
                 "cmd" => EventData::Cmd(text),
                 _ => unreachable!(),

--- a/tests/help_tag_test.rs
+++ b/tests/help_tag_test.rs
@@ -1,0 +1,60 @@
+#[test]
+fn test_no_help_tag() {
+    let script = r###"
+# @cmd
+cmd() { :; }
+    "###;
+    plain!(script, &["prog"], stderr: r#"prog 
+
+USAGE:
+    prog <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    cmd     
+    help    Print this message or the help of the given subcommand(s)
+"#,);
+}
+
+#[test]
+fn test_no_help_subcommand() {
+    let script = r###"
+# @help false
+# @cmd
+cmd() { :; }
+    "###;
+    plain!(script, &["prog"], stderr: r#"prog 
+
+USAGE:
+    prog <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    cmd    
+"#,);
+}
+
+#[test]
+fn test_custom_help_subcommand_about() {
+    let script = r###"
+# @help Print help information
+# @cmd
+cmd() { :; }
+    "###;
+    plain!(script, &["prog"], stderr: r#"prog 
+
+USAGE:
+    prog <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    cmd     
+    help    Print help information
+"#,);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,5 +2,6 @@
 mod macros;
 mod escape_test;
 mod fail_test;
+mod help_tag_test;
 mod main_fn_test;
 mod spec_test;


### PR DESCRIPTION
disable help subcommand with `# @help false`
custom help subcommand message with `# @help Print help information`