### PR TITLE
fix: convert hyphens to underscores in positionals, flags and options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -279,7 +279,7 @@ fn to_string_retrieve_values(values: Vec<RetrieveValue>) -> String {
     for value in values {
         match value {
             RetrieveValue::Single(name, value) => {
-                variables.push(format!("{}_{}={}", VARIABLE_PREFIX, name, value));
+                variables.push(format!("{}_{}={}", VARIABLE_PREFIX, hyphens_to_underscores(name), value));
             }
             RetrieveValue::Multiple(name, values) => {
                 variables.push(format!(
@@ -290,14 +290,14 @@ fn to_string_retrieve_values(values: Vec<RetrieveValue>) -> String {
                 ));
             }
             RetrieveValue::PositionalSingle(name, value) => {
-                variables.push(format!("{}_{}={}", VARIABLE_PREFIX, name, &value));
+                variables.push(format!("{}_{}={}", VARIABLE_PREFIX, hyphens_to_underscores(name), &value));
                 positional_args.push(value);
             }
             RetrieveValue::PositionalMultiple(name, values) => {
                 variables.push(format!(
                     "{}_{}=( {} )",
                     VARIABLE_PREFIX,
-                    name,
+                    hyphens_to_underscores(name),
                     values.join(" ")
                 ));
                 positional_args.extend(values);
@@ -316,4 +316,8 @@ fn to_string_retrieve_values(values: Vec<RetrieveValue>) -> String {
 
 fn unexpected_param(tag_name: &str, pos: Position) -> Error {
     anyhow!("{}(line {}) is unexpected, maybe miss @cmd?", tag_name, pos,)
+}
+
+fn hyphens_to_underscores(name: &str) -> String {
+    name.replace("-", "_")
 }

--- a/tests/snapshots/integration__spec_test__spec_cmd_with_hyphens.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_with_hyphens.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec_test.rs
+assertion_line: 213
+expression: output
+---
+RUN
+spec cmd_with_hyphens foo --hyphen-flag --hyphen-option bar
+
+STDOUT
+argc_hyphen_positional=foo
+argc_hyphen_flag=1
+argc_hyphen_option=bar
+cmd_with_hyphens foo
+
+STDERR
+
+

--- a/tests/snapshots/integration__spec_test__spec_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_help.snap
@@ -48,6 +48,8 @@ SUBCOMMANDS:
             Positional with default value
     cmd_preferred
             Preferred
+    cmd_with_hyphens
+            Command with hyphens
     cmd_without_any_arg
             Command without any arg
     help

--- a/tests/spec.sh
+++ b/tests/spec.sh
@@ -109,6 +109,14 @@ cmd_alias() {
     print_argc_vars
 }
 
+# @cmd  Command with hyphens
+# @arg       hyphen-positional
+# @flag     --hyphen-flag
+# @option   --hyphen-option
+cmd_with_hyphens() {
+    print_argc_vars
+}
+
 print_argc_vars() {
     ( set -o posix ; set ) | grep argc_
 }

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -206,3 +206,18 @@ fn test_spec_cmd_without_any_arg_exec_eval() {
         &["spec", "cmd_without_any_arg", "foo", "bar"],
     );
 }
+
+#[test]
+fn test_spec_cmd_with_hyphens() {
+    snapshot!(
+        include_str!("spec.sh"),
+        &[
+            "spec",
+            "cmd_with_hyphens",
+            "foo",
+            "--hyphen-flag",
+            "--hyphen-option",
+            "bar"
+        ],
+    );
+}


### PR DESCRIPTION
Hey, I noticed if I added a positional, flag or an option with hyphens in it, the resulting script failed to run because it tried to set variables like `argc_hyphen-option=foo` (from `--hyphen-option foo`). So I made a change to convert the hyphens to underscores.

Whether you want to include this change or not, I would suggest mentioning how hyphens are handled in the README. 