### PR TITLE
feat: works as command runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "convert_case",
  "insta",
  "nom",
+ "which",
 ]
 
 [[package]]
@@ -34,9 +35,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "clap"
-version = "3.2.14"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54635806b078b7925d6e36810b1755f2a4b5b4d57560432c1ecf60bcbe10602b"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
 dependencies = [
  "bitflags",
  "clap_lex",
@@ -82,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
 
 [[package]]
+name = "either"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +129,12 @@ name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -171,9 +184,9 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -274,6 +287,17 @@ name = "unicode-ident"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,20 +3,21 @@ name = "argc"
 version = "0.8.2"
 edition = "2021"
 authors = ["sigoden <sigoden@gmail.com>"]
-description = "A new way to parse shell script arguments."
+description = "Bash cli utility"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/sigoden/argc"
 repository = "https://github.com/sigoden/argc"
 autotests = false
 categories = ["command-line-utilities"]
-keywords = ["command-line", "shell-script", "argument-parser"]
+keywords = ["command-line", "bash-script", "command-runner"]
 
 [dependencies]
 anyhow = "1"
 clap = { version = "3", default_features = false, features = ["std"] }
-clap_complete = "3.2.3"
+clap_complete = "3.2"
 convert_case = "0.5"
 nom = "7.1"
+which = "4.2"
 
 [dev-dependencies]
 insta = "1.15"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Usage
 
-### Comment bash to make cli
+### Make beautiful CLI with comments
 
 ![demo](https://user-images.githubusercontent.com/4012553/158063004-e7a3534c-eb1a-47fb-9bbd-89a49345589a.gif)
 
@@ -33,6 +33,13 @@ Try [examples/demo.sh](examples/demo.sh) your self.
 
 ### Command Runner
 
+When argc is executed without the `--argc-*` option, it will search for the argcfile file in the current project and its parent directory and execute it.
+
+`argcfile` is to `argc` what `makefile` is to `make`．
+
+
+> Note: in windows, you need to install git to provide bash for argc
+
 
 ### Generate bash completion script
 
@@ -53,7 +60,7 @@ cargo install argc
 
 Download from [Github Releases](https://github.com/sigoden/argc/releases), unzip and add argc to your $PATH.
 
-## Tag 
+## Tag
 
 Argc generates parsing rules and help documentation based on tags (fields marked with `@` in comments).
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,20 @@
 [![CI](https://github.com/sigoden/argc/actions/workflows/ci.yaml/badge.svg)](https://github.com/sigoden/argc/actions/workflows/ci.yaml)
 [![Crates](https://img.shields.io/crates/v/argc.svg)](https://crates.io/crates/argc)
 
-A new way to parse shell script arguments to make writing bash cli easier. Time to say goodbye to bash getopt(s).
+## Usage
+
+### Comment bash to make cli
 
 ![demo](https://user-images.githubusercontent.com/4012553/158063004-e7a3534c-eb1a-47fb-9bbd-89a49345589a.gif)
-
-## How Argc works
 
 To write a command-line program with Argc, we only need to do two things:
 
 1. Describe the options, parameters, and subcommands in comments
 2. Call the following command to entrust Argc to process command line parameters for us
 
+
 ```sh
-eval "$(argc $0 "$@")"
+eval "$(argc --argc-eval $0 "$@")"
 ```
 
 Argc will do the following for us:
@@ -30,6 +31,16 @@ We can easily access the corresponding option or parameter through the variable 
 
 Try [examples/demo.sh](examples/demo.sh) your self.
 
+### Command Runner
+
+
+### Generate bash completion script
+
+```
+argc --argc-completion examples/demo.sh
+```
+
+
 ## Install
 
 ### With cargo
@@ -42,7 +53,7 @@ cargo install argc
 
 Download from [Github Releases](https://github.com/sigoden/argc/releases), unzip and add argc to your $PATH.
 
-## Tag
+## Tag 
 
 Argc generates parsing rules and help documentation based on tags (fields marked with `@` in comments).
 
@@ -197,6 +208,26 @@ Define flag option
 Define positional argument
 
 arg's modifier is same to [option's modifier](#modifier)
+
+## Cli
+
+```
+Bash cli utility - https://github.com/sigoden/argc
+
+USAGE:
+    argc [OPTIONS] [ARGS]
+
+ARGS:
+    <SCRIPT>          Specific script file
+    <ARGUMENTS>...    Arguments passed to script file
+
+OPTIONS:
+        --argc-completion    Print bash completion script
+        --argc-eval          Print code snippets for eval
+        --argc-help          Print help information
+        --argc-version       Print version information
+```
+
 
 ## License
 

--- a/argcfile
+++ b/argcfile
@@ -1,0 +1,39 @@
+#!/bin/bash 
+set -eo pipefail
+
+PKG_NAME=argc
+
+# @cmd Build binary and install
+# @alias i
+install() {
+    cargo build -r
+    ls -alh target/release/$PKG_NAME
+    cp target/release/$PKG_NAME $HOME/.cargo/bin
+}
+
+# @cmd Check outdated deps
+outdated() {
+    cargo outdated --root-deps-only $@
+}
+
+# @cmd Test all crates and modules
+# @alias t,test
+tst() {
+    cargo test --all
+}
+
+# @cmd Format/clippy code
+fmt() {
+    cargo clippy --all --all-targets
+    cargo fmt --all
+}
+
+# @cmd Run before commit
+# @alias pc
+pre:commit() {
+    fmt
+    outdated --exit-code 1
+    tst
+}
+
+eval "$(argc --argc-eval $0 "$@")"

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -22,4 +22,4 @@ download() {
     echo "arg:    target            $argc_target"
 }
 
-eval "$(argc $0 "$@")"
+eval "$(argc --argc-eval $0 "$@")"

--- a/examples/options.sh
+++ b/examples/options.sh
@@ -8,7 +8,7 @@
 # @option      -y --opt7[=x|y|z]   A option with choices and default value
 # @option      -z --opt8![x|y|z]   A required option with choices
 
-eval "$(argc $0 "$@")"
+eval "$(argc --argc-eval $0 "$@")"
 
 
 ( set -o posix ; set ) | grep argc_ # print variables with argc_ prefix

--- a/examples/subcmds.sh
+++ b/examples/subcmds.sh
@@ -49,6 +49,6 @@ cmd8() {
 }
 
 
-eval "$(argc $0 "$@")"
+eval "$(argc --argc-eval $0 "$@")"
 
 ( set -o posix ; set ) | grep argc_ # print variables with argc_ prefix

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,11 +12,11 @@ const VARIABLE_PREFIX: &str = env!("CARGO_CRATE_NAME");
 
 const ENTRYPOINT: &str = "main";
 
-pub struct Runner<'a> {
+pub struct Cli<'a> {
     source: &'a str,
 }
 
-impl<'a> Runner<'a> {
+impl<'a> Cli<'a> {
     pub fn new(source: &'a str) -> Self {
         Self { source }
     }
@@ -46,12 +46,6 @@ impl<'a> Runner<'a> {
             Err(err) => Ok(Err(err.to_string())),
         }
     }
-}
-
-/// Run script with arguments, returns (stdout, stderr)
-pub fn run<'a>(source: &'a str, args: &[&'a str]) -> Result<std::result::Result<String, String>> {
-    let runner = Runner::new(source);
-    runner.run(args)
 }
 
 #[derive(Default)]
@@ -225,7 +219,7 @@ impl<'a> Cmd<'a> {
         Ok(cmd)
     }
 
-    fn retrieve(&'a self, matches: &ArgMatches, runner: &Runner) -> Vec<RetrieveValue> {
+    fn retrieve(&'a self, matches: &ArgMatches, cli: &Cli) -> Vec<RetrieveValue> {
         let mut values = vec![];
         for (param, _) in &self.params {
             if let Some(value) = param.retrieve_value(matches) {
@@ -237,7 +231,7 @@ impl<'a> Cmd<'a> {
             if let Some(fn_name) = &subcommand.name {
                 if let Some((match_name, subcommand_matches)) = matches.subcommand() {
                     if *fn_name == match_name {
-                        let subcommand_values = subcommand.retrieve(subcommand_matches, runner);
+                        let subcommand_values = subcommand.retrieve(subcommand_matches, cli);
                         values.extend(subcommand_values);
                         call_fn = Some(fn_name);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,6 @@ mod parser;
 mod utils;
 
 use anyhow::Error;
-pub use cli::{run, Runner};
+pub use cli::Cli;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ fn parse_script_args(args: &[String]) -> Result<(String, Vec<String>)> {
 }
 
 fn get_script_path() -> Option<(PathBuf, PathBuf)> {
-	let name = get_script_name();
+    let name = get_script_name();
     let mut dir = env::current_dir().ok()?;
     loop {
         let path = dir.join(&name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,53 +1,69 @@
-use anyhow::{anyhow, Result};
-use clap::{arg, ArgMatches, Command, ErrorKind};
-use std::{env, fs, io, path::Path, process};
+use anyhow::{anyhow, bail, Result};
+use clap::{arg, ArgAction, Command};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+    process,
+};
+use which::which;
 
 fn main() {
-    let mut args: Vec<String> = vec![];
-    let mut script_args: Vec<String> = vec![];
-    for arg in std::env::args() {
-        if script_args.is_empty() {
-            if !args.is_empty() && !arg.trim().starts_with('-') {
-                script_args.push(arg.clone());
+    match run() {
+        Ok(code) => {
+            if code != 0 {
+                process::exit(code);
             }
-            args.push(arg)
-        } else {
-            script_args.push(arg);
         }
-    }
-    let res = Command::new(env!("CARGO_CRATE_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .author(env!("CARGO_PKG_AUTHORS"))
-        .disable_help_subcommand(true)
-        .about(concat!(
-            env!("CARGO_PKG_DESCRIPTION"),
-            " - ",
-            env!("CARGO_PKG_REPOSITORY")
-        ))
-        .arg(arg!(-e --eval "Adjust to run in sh eval").hide(true)) // will be removed in v1.0
-        .arg(arg!(-c --completion "Print bash completion script"))
-        .arg(arg!(<SCRIPT> "Script file to be parsed"))
-        .arg(arg!([ARGUMENTS]... "Arguments passed to script file"))
-        .try_get_matches_from(&args);
-
-    if let Err(err) = res.map(|v| start(v, &script_args)) {
-        if err.kind() == ErrorKind::DisplayHelp {
-            println!("{}", err);
-        } else {
+        Err(err) => {
             eprintln!("{}", err);
             process::exit(1);
         }
     }
 }
 
-fn start(matches: ArgMatches, script_args: &[String]) -> Result<()> {
-    let (source, cmd_args) = proc_script_args(script_args)?;
-    let runner = argc::Runner::new(&source);
-    let cmd_args: Vec<&str> = cmd_args.iter().map(|v| v.as_str()).collect();
-    if matches.is_present("completion") {
-        runner.complete(cmd_args[0], &mut io::stdout())?;
-    } else {
-        match runner.run(&cmd_args)? {
+fn run() -> Result<i32> {
+    let mut args: Vec<String> = vec![];
+    let mut script_args: Vec<String> = vec![];
+    for (i, arg) in std::env::args().enumerate() {
+        if i == 0 {
+            args.push(arg);
+            continue;
+        }
+        if script_args.is_empty() && arg.starts_with("--argc-") {
+            args.push(arg);
+            continue;
+        }
+        script_args.push(arg);
+    }
+    let matches = Command::new(env!("CARGO_CRATE_NAME"))
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .disable_help_flag(true)
+        .disable_version_flag(true)
+        .disable_help_subcommand(true)
+        .about(concat!(
+            env!("CARGO_PKG_DESCRIPTION"),
+            " - ",
+            env!("CARGO_PKG_REPOSITORY")
+        ))
+        .arg(arg!(--"argc-eval" "Print code snippets for eval"))
+        .arg(arg!(--"argc-completion" "Print bash completion script"))
+        .arg(arg!(--"argc-version" "Print version information").action(ArgAction::Version))
+        .arg(arg!(--"argc-help" "Print help information").action(ArgAction::Help))
+        .arg(arg!([SCRIPT] "Specific script file"))
+        .arg(arg!([ARGUMENTS]... "Arguments passed to script file"))
+        .try_get_matches_from(&args)?;
+
+    if matches.is_present("argc-completion") {
+        let (source, cmd_args) = parse_script_args(&script_args)?;
+        let cli = argc::Cli::new(&source);
+        let cmd_args: Vec<&str> = cmd_args.iter().map(|v| v.as_str()).collect();
+        cli.complete(cmd_args[0], &mut io::stdout())?;
+    } else if matches.is_present("argc-eval") {
+        let (source, cmd_args) = parse_script_args(&script_args)?;
+        let cli = argc::Cli::new(&source);
+        let cmd_args: Vec<&str> = cmd_args.iter().map(|v| v.as_str()).collect();
+        match cli.run(&cmd_args)? {
             Ok(stdout) => {
                 println!("{}", stdout)
             }
@@ -56,20 +72,57 @@ fn start(matches: ArgMatches, script_args: &[String]) -> Result<()> {
                 println!("exit 1");
             }
         }
+    } else {
+        if env::var("ARGC_MODE").is_ok() {
+            bail!("Recognized an infinite loop, did you forget to add the `--argc-eval` option in eval");
+        }
+        let shell = get_shell_path().ok_or_else(|| anyhow!("Not found shell"))?;
+        let (script_dir, script_file) =
+            get_script_path().ok_or_else(|| anyhow!("Not found script file"))?;
+        let mut command = process::Command::new(&shell);
+        command.arg(&script_file);
+        command.args(&script_args);
+        command.current_dir(script_dir);
+        command.env("ARGC_MODE", "true");
+        let status = command
+            .status()
+            .map_err(|err| anyhow!("Run `{}` throw {}", script_file, err))?;
+        return Ok(status.code().unwrap_or_default());
     }
-    Ok(())
+    Ok(0)
 }
 
-fn proc_script_args(args: &[String]) -> Result<(String, Vec<String>)> {
+fn parse_script_args(args: &[String]) -> Result<(String, Vec<String>)> {
+    if args.is_empty() {
+        bail!("No script file");
+    }
     let script_file = args[0].as_str();
     let args: Vec<String> = args[1..].to_vec();
+    let source = fs::read_to_string(script_file)
+        .map_err(|e| anyhow!("Failed to load '{}', {}", script_file, e))?;
     let name = Path::new(script_file)
         .file_stem()
         .and_then(|v| v.to_str())
-        .ok_or_else(|| anyhow!("Fail to get command name"))?;
-    let source = fs::read_to_string(script_file)
-        .map_err(|e| anyhow!("Fail to load '{}', {}", script_file, e))?;
+        .ok_or_else(|| anyhow!("Failed to get script name"))?;
     let mut cmd_args = vec![name.to_string()];
     cmd_args.extend(args);
     Ok((source, cmd_args))
+}
+
+fn get_script_path() -> Option<(PathBuf, String)> {
+    let name = env::var("ARGC_SCRIPT").unwrap_or_else(|_| "argcfile".into());
+    let mut dir = env::current_dir().ok()?;
+    loop {
+        let path = dir.join(&name);
+        if path.exists() {
+            return Some((dir, path.to_string_lossy().to_string()));
+        }
+        dir = dir.parent()?.to_path_buf();
+    }
+}
+
+fn get_shell_path() -> Option<String> {
+    let exe = env::var("ARGC_SHELL").unwrap_or_else(|_| "bash".into());
+    let path = which(exe).ok()?;
+    Some(path.to_string_lossy().to_string())
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -4,8 +4,8 @@ macro_rules! snapshot {
         $source:expr,
         $args:expr,
     ) => {
-        let runner = argc::Runner::new($source);
-        let (stdout, stderr) = match runner.run($args).unwrap() {
+        let cli = argc::Cli::new($source);
+        let (stdout, stderr) = match cli.run($args).unwrap() {
             Ok(stdout) => (stdout, String::new()),
             Err(stderr) => (String::new(), stderr),
         };
@@ -35,7 +35,8 @@ macro_rules! plain {
         $(stdout: $stdout:expr,)?
         $(stderr: $stderr:expr,)?
     ) => {
-        let result = match argc::run($source, $args).unwrap()  {
+        let cli = argc::Cli::new($source);
+        let result = match cli.run($args).unwrap()  {
             Ok(stdout) => (stdout, String::new()),
             Err(stderr) => (String::new(), stderr),
         };
@@ -55,7 +56,8 @@ macro_rules! fatal {
         $args:expr,
         $err:expr
     ) => {
-        let err = argc::run($source, $args).unwrap_err();
+        let cli = argc::Cli::new($source);
+        let err = cli.run($args).unwrap_err();
         assert_eq!(err.to_string().as_str(), $err);
     };
 }
@@ -66,9 +68,9 @@ macro_rules! complete {
         $source:expr,
         $name:expr
     ) => {
-        let runner = argc::Runner::new($source);
+        let cli = argc::Cli::new($source);
         let mut bufs: Vec<u8> = vec![];
-        runner.complete($name, &mut bufs).unwrap();
+        cli.complete($name, &mut bufs).unwrap();
         let output = std::str::from_utf8(&bufs).unwrap();
         insta::assert_snapshot!(output);
     };


### PR DESCRIPTION
argc will works as command runner. 

You create build script  named `argcfile`
```
#!/bin/bash 
set -eo pipefail

# @cmd Test all crates and modules
# @alias t,test
tst() {
    cargo test --all
}

# @cmd Format/clippy code
fmt() {
    cargo clippy --all --all-targets
    cargo fmt --all
}

eval "$(argc --argc-eval $0 "$@")"
```
run `argc` equals to `bash argcfile`， argc will search for `argcfile` then execute it. like make/makefile.

```
argcfile 

USAGE:
    argcfile <SUBCOMMAND>

OPTIONS:
    -h, --help    Print help information

SUBCOMMANDS:
    fmt     Format/clippy code
    help    Print this message or the help of the given subcommand(s)
    tst     Test all crates and modules [aliases: t, test]
```

