### PR TITLE
fix: change `--compgen` to `--argc-compgen` in completions

### DIFF
--- a/completions/argc.bash
+++ b/completions/argc.bash
@@ -13,7 +13,7 @@ _argc_completion() {
     if [ $? != 0 ]; then
         return 0
     fi
-    opts=$(argc --compgen "$argcfile" ${COMP_WORDS[@]:1:$((${#COMP_WORDS[@]} - 2))} 2>/dev/null)
+    opts=$(argc --argc-compgen "$argcfile" ${COMP_WORDS[@]:1:$((${#COMP_WORDS[@]} - 2))} 2>/dev/null)
     COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
     return 0
 }

--- a/completions/argc.ps1
+++ b/completions/argc.ps1
@@ -19,7 +19,7 @@ $_argc_completion = {
     } else {
         $cmds = $commandAst.CommandElements[1..($commandAst.CommandElements.Count - 1)]
     }
-    (argc --compgen "$argcfile" $cmds 2>$null) -split " " | 
+    (argc --argc-compgen "$argcfile" $cmds 2>$null) -split " " |
         Where-Object { $_ -like "$wordToComplete*" } |
         ForEach-Object { 
             if ($_.StartsWith("-")) {

--- a/completions/argc.zsh
+++ b/completions/argc.zsh
@@ -12,7 +12,7 @@ _argc_completion()
     if [[ $? -ne 0 ]]; then
         return 0
     fi
-    values=( $(argc --compgen "$argcfile" $words[2,-2] 2>/dev/null) )
+    values=( $(argc --argc-compgen "$argcfile" $words[2,-2] 2>/dev/null) )
     compadd -- $values[@]
     return 0
 }


### PR DESCRIPTION
Hey, 

I noticed the completion scripts were still using `--compgen` when you're supposed to be using `--argc-compgen` with the recent versions of argc. This PR should fix that.