### PR TITLE
feat: value name supports notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ COMMANDS:
 ### @arg
 
 ```
-@arg <name>[modifier] [help string]
+@arg <name>[modifier] [notation] [help string]
 ```
 
 Define a positional argument.
@@ -113,15 +113,16 @@ Define a positional argument.
 ```sh
 # @arg arg1            A positional argument
 # @arg arg2!           A required positional argument
-# @arg arg3*           A positional argument support multiple values
-# @arg arg4+           A required positional argument support multiple values
-# @arg arg5=a          A positional argument with default value
-# @arg arg6=`_fn`      A positional argument with default value from fn
-# @arg arg7[a|b]       A positional argument with choices
-# @arg arg8[`_fn`]     A positional argument with choices from fn
-# @arg arg9[=a|b]      A positional argument with choices and default value
-# @arg arg10![a|b]     A required positional argument with choices
-# @arg arg11![`_fn`]   A required positional argument with choices from fn
+# @arg arg3 <PATH>     A positional argument with notation
+# @arg arg4*           A positional argument support multiple values
+# @arg arg5+           A required positional argument support multiple values
+# @arg arg6=a          A positional argument with default value
+# @arg arg7=`_fn`      A positional argument with default value from fn
+# @arg arg8[a|b]       A positional argument with choices
+# @arg arg9[`_fn`]     A positional argument with choices from fn
+# @arg arg10[=a|b]     A positional argument with choices and default value
+# @arg arg11![a|b]     A required positional argument with choices
+# @arg arg12![`_fn`]   A required positional argument with choices from fn
 ```
 
 ### @option

--- a/examples/subcmds.sh
+++ b/examples/subcmds.sh
@@ -5,46 +5,52 @@ cmd1() {
     :;
 }
 
+# @cmd A simple positional argument with notation
+# @arg value <PATH>
+cmd2() {
+    :;
+}
+
 # @cmd A required positional argument
 # @arg value!
-cmd2() {
+cmd3() {
     :;
 }
 
 # @cmd A positional argument support multiple values
 # @arg value*
-cmd3() {
+cmd4() {
     :;
 }
 
 # @cmd A required positional argument support multiple values
 # @arg value*
-cmd4() {
+cmd5() {
     :;
 }
 
 # @cmd A positional argument with default value
 # @arg value=a
-cmd5() {
+cmd6() {
     :;
 }
 
 # @cmd A positional argument with choices
 # @arg value[x|y|z]
-cmd6() {
+cmd7() {
     :;
 }
 
 
 # @cmd A positional argument with choices and default value
 # @arg value[=x|y|z]
-cmd7() {
+cmd8() {
     :;
 }
 
 # @cmd A required positional argument with choices
 # @arg value![x|y|z]
-cmd8() {
+cmd9() {
     :;
 }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -133,9 +133,8 @@ impl OptionParam {
         short: Option<char>,
         value_name: Option<&str>,
     ) -> Self {
-        let arg_name = arg.name.clone();
         OptionParam {
-            name: arg.name,
+            name: arg.name.clone(),
             summary: summary.to_string(),
             choices: arg.choices,
             choices_fn: arg.choices_fn,
@@ -146,7 +145,7 @@ impl OptionParam {
             short,
             value_name: value_name.map(|v| v.to_string()),
             arg_value_name: value_name
-                .or(Some(&arg_name))
+                .or(Some(&arg.name))
                 .map(to_cobol_case)
                 .unwrap_or_default(),
         }
@@ -245,6 +244,7 @@ impl Param for OptionParam {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct PositionalParam {
     pub(crate) name: String,
+    pub(crate) value_name: Option<String>,
     pub(crate) summary: String,
     pub(crate) choices: Option<Vec<String>>,
     pub(crate) choices_fn: Option<String>,
@@ -256,10 +256,9 @@ pub struct PositionalParam {
 }
 
 impl PositionalParam {
-    pub fn new(arg: ParamData, summary: &str) -> Self {
-        let arg_value_name = to_cobol_case(&arg.name);
+    pub fn new(arg: ParamData, summary: &str, value_name: Option<&str>) -> Self {
         PositionalParam {
-            name: arg.name,
+            name: arg.name.clone(),
             summary: summary.to_string(),
             choices: arg.choices,
             choices_fn: arg.choices_fn,
@@ -267,7 +266,11 @@ impl PositionalParam {
             required: arg.required,
             default: arg.default,
             default_fn: arg.default_fn,
-            arg_value_name,
+            value_name: value_name.map(|v| v.to_string()),
+            arg_value_name: value_name
+                .or(Some(&arg.name))
+                .map(to_cobol_case)
+                .unwrap_or_default(),
         }
     }
 
@@ -281,6 +284,7 @@ impl PositionalParam {
             required: false,
             default: None,
             default_fn: None,
+            value_name: None,
             arg_value_name: EXTRA_ARGS.to_string(),
         }
     }
@@ -307,6 +311,9 @@ impl Param for PositionalParam {
             &self.default_fn,
         );
         output.push(name);
+        if let Some(value_name) = self.value_name.as_ref() {
+            output.push(format!("<{}>", value_name));
+        }
         render_summary(&mut output, &self.summary);
         output.join(" ")
     }

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_only_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_only_help.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec_test.rs
-assertion_line: 40
 expression: output
 ---
 RUN
@@ -12,9 +11,9 @@ STDOUT
 STDERR
 Positional one required
 
-USAGE: spec cmd_positional_only <ARG1>
+USAGE: spec cmd_positional_only <ARG>
 
 ARGS:
-  <ARG1>  A required arg
+  <ARG>  A required arg
 
 

--- a/tests/spec.sh
+++ b/tests/spec.sh
@@ -65,7 +65,7 @@ cmd_flag_formats() {
 }
 
 # @cmd  Positional one required
-# @arg   arg1!     A required arg
+# @arg   arg1! <ARG>  A required arg
 cmd_positional_only() {
     print_argc_vars
 }


### PR DESCRIPTION
```
# @arg foo <PATH>   A positional argument with notation
```