### PR TITLE
feat: redesign compgen, break changes to completion scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ COMMANDS:
 ### @arg
 
 ```
-@arg <name>[modifier] [notation] [help string]
+@arg <name>[modifier] [value notation] [help string]
 ```
 
 Define a positional argument.
@@ -113,7 +113,7 @@ Define a positional argument.
 ```sh
 # @arg arg1            A positional argument
 # @arg arg2!           A required positional argument
-# @arg arg3 <PATH>     A positional argument with notation
+# @arg arg3 <PATH>     A positional argument with value notation
 # @arg arg4*           A positional argument support multiple values
 # @arg arg5+           A required positional argument support multiple values
 # @arg arg6=a          A positional argument with default value
@@ -128,7 +128,7 @@ Define a positional argument.
 ### @option
 
 ```
-@option [short] <long>[modifier] [notation] [help string]
+@option [short] <long>[modifier] [value notation] [help string]
 ```
 
 Define a option.
@@ -136,7 +136,7 @@ Define a option.
 ```sh
 # @option    --opt1                 A option
 # @option -a --opt2                 A option with short alias
-# @option    --opt3 <PATH>          A option with notation
+# @option    --opt3 <PATH>          A option with value notation
 # @option    --opt4!                A required option
 # @option    --opt5*                A option with multiple values
 # @option    --opt6+                A required option with multiple values
@@ -147,7 +147,7 @@ Define a option.
 # @option    --opt11[=a|b]          A option with choices and default value
 # @option    --opt12![a|b]          A required option with choices
 # @option    --opt13![`_fn`]        A required option with choices from fn
-# @option -b --opt14 <PATH>         A option with short alias and notation
+# @option -b --opt14 <PATH>         A option with short alias and value notation
 ```
 
 ### @flag
@@ -238,6 +238,21 @@ USAGE: test.sh <COMMAND>
 COMMANDS:
   test  Run test
 ```
+
+### Value Notation
+
+Value notation is used to describe value type of options and positional parameters.
+
+```
+# @option --target <FILE>
+# @arg target <FILE>
+```
+
+Here are some value notation that will affect the shell completion.
+
+- `<FILE>`: complete files in current directory
+- `<DIR>`: complete directories in current directory
+- `<PATH>`: complete files and directories in current directory
 
 ## Shell Completion
 

--- a/completions/argc.bash
+++ b/completions/argc.bash
@@ -21,11 +21,19 @@ _argc_completion() {
     elif [[ ${#opts[@]} == 1 ]]; then
         if [[ "$opts" == \`*\` ]]; then
             opts=($(bash "$argcfile" "${opts:1:-1}" 2>/dev/null))
+        elif [[ "$opts" == "<FILE>" ]] || [[ "$opts" == "<PATH>" ]] || [[ "$opts" == "<FILE>..." ]] || [[ "$opts" == "<PATH>..." ]]; then
+            opts=()
+            compopt +o filenames 
+        elif [[ "$opts" == "<DIR>" ]] || [[ "$opts" == "<DIR>..." ]]; then
+            opts=()
+            compopt +o dirnames
         fi
     fi
-    CANDIDATES=($(compgen -W "${opts[*]}" -- "${cur}"))
-    if [ ${#CANDIDATES[*]} -gt 0 ]; then
-        COMPREPLY=($(printf '%q\n' "${CANDIDATES[@]}"))
+    if [[ ${#opts[@]} -gt 0 ]]; then
+        CANDIDATES=($(compgen -W "${opts[*]}" -- "${cur}"))
+        if [ ${#CANDIDATES[*]} -gt 0 ]; then
+            COMPREPLY=($(printf '%q\n' "${CANDIDATES[@]}"))
+        fi
     fi
 }
 

--- a/completions/argc.bash
+++ b/completions/argc.bash
@@ -6,20 +6,27 @@
 ARGC_SCRIPTS=( mycmd1 mycmd2 )
 
 _argc_completion() {
-    local argcfile cur opts
+    local argcfile cur opts line index IFS
     cur="${COMP_WORDS[COMP_CWORD]}"
     COMPREPLY=()
     argcfile=$(which ${COMP_WORDS[0]})
-    if [ $? != 0 ]; then
+    if [[ $? != 0 ]]; then
         return 0
     fi
-    opts=$(argc --compgen "$argcfile" ${COMP_WORDS[@]:1:$((${#COMP_WORDS[@]} - 2))} 2>/dev/null)
-    if [[ "$opts" = __argc_compgen_cmd:* ]]; then
-        COMPREPLY=( $(compgen -W "$(bash "$argcfile" ${opts#__argc_compgen_cmd:} 2>/dev/null)" -- "${cur}") )
-    else
-        COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+    line=${COMP_LINE:${#COMP_WORDS[0]}}
+    IFS=$'\n'
+    opts=($(argc --compgen "$argcfile" "$line" 2>/dev/null))
+    if [[ ${#opts[@]} == 0 ]]; then
+        return 0
+    elif [[ ${#opts[@]} == 1 ]]; then
+        if [[ "$opts" == \`*\` ]]; then
+            opts=($(bash "$argcfile" "${opts:1:-1}" 2>/dev/null))
+        fi
     fi
-    return 0
+    CANDIDATES=($(compgen -W "${opts[*]}" -- "${cur}"))
+    if [ ${#CANDIDATES[*]} -gt 0 ]; then
+        COMPREPLY=($(printf '%q\n' "${CANDIDATES[@]}"))
+    fi
 }
 
 complete -F _argc_completion -o bashdefault -o default ${ARGC_SCRIPTS[@]}

--- a/completions/argc.fish
+++ b/completions/argc.fish
@@ -17,7 +17,7 @@ function __fish_complete_argc
     if [ (count $opts) = 0 ]
         return 0
     else if [ (count $opts) = 1 ]
-        if string match -qr '`\w+`' -- "$opts[1]"
+        if string match -qr '^`[^` ]+`' -- "$opts[1]"
             set -l name (string sub $opts[1] -s 2 -e -1)
             set opts (bash "$argcfile" $name 2>/dev/null)
         end

--- a/completions/argc.fish
+++ b/completions/argc.fish
@@ -6,18 +6,25 @@
 set ARGC_SCRIPTS mycmd1 mycmd2
 
 function __fish_complete_argc
-    set -l line (commandline -opc) (commandline -ct)
-    set -l tokens (echo $line | string trim | string split " " --)
+    echo BEGIN > /tmp/file1
+    set -l tokens (commandline -c | string trim -l | string split " " --)
     set -l argcfile (which $tokens[1])
     if test -z $argcfile
         return 0
     end
-    set -l opts (argc --compgen "$argcfile" $tokens[2..-1] 2>/dev/null)
-    if string match -q "__argc_compgen_cmd:*" -- $opts
-        set -l fn_name (string replace "__argc_compgen_cmd:" "" $opts)
-        set opts (bash "$argcfile" $fn_name 2>/dev/null)
+    set -l IFS '\n'
+    set -l opts (argc --compgen "$argcfile" "$tokens[2..]" 2>/dev/null)
+    if [ (count $opts) = 0 ]
+        return 0
+    else if [ (count $opts) = 1 ]
+        if string match -qr '`\w+`' -- "$opts[1]"
+            set -l name (string sub $opts[1] -s 2 -e -1)
+            set opts (bash "$argcfile" $name 2>/dev/null)
+        end
     end
-    echo $opts | string trim | string split " " --
+    for item in $opts
+        echo $item
+    end
 end
 
 for argc_script in $ARGC_SCRIPTS

--- a/completions/argc.fish
+++ b/completions/argc.fish
@@ -6,7 +6,6 @@
 set ARGC_SCRIPTS mycmd1 mycmd2
 
 function __fish_complete_argc
-    echo BEGIN > /tmp/file1
     set -l tokens (commandline -c | string trim -l | string split " " --)
     set -l argcfile (which $tokens[1])
     if test -z $argcfile

--- a/completions/argc.fish
+++ b/completions/argc.fish
@@ -20,6 +20,12 @@ function __fish_complete_argc
         if string match -qr '^`[^` ]+`' -- "$opts[1]"
             set -l name (string sub $opts[1] -s 2 -e -1)
             set opts (bash "$argcfile" $name 2>/dev/null)
+        else if test "$opts[1]" = "<FILE>" || test "$opts[1]" = "<PATH>" || test "$opts[1]" = "<FILE>..." || test "$opts[1]" = "<PATH>..."
+            set opts ()
+            __fish_complete_path
+        else if test "$opts[1]" = "<DIR>" || test "$opts[1]" = "<DIR>..."
+            set opts ()
+            __fish_complete_directories 
         end
     end
     for item in $opts

--- a/completions/argc.fish
+++ b/completions/argc.fish
@@ -19,16 +19,16 @@ function __fish_complete_argc
         if string match -qr '^`[^` ]+`' -- "$opts[1]"
             set -l name (string sub $opts[1] -s 2 -e -1)
             set opts (bash "$argcfile" $name 2>/dev/null)
-        else if test "$opts[1]" = "<FILE>" || test "$opts[1]" = "<PATH>" || test "$opts[1]" = "<FILE>..." || test "$opts[1]" = "<PATH>..."
-            set opts ()
-            __fish_complete_path
-        else if test "$opts[1]" = "<DIR>" || test "$opts[1]" = "<DIR>..."
-            set opts ()
-            __fish_complete_directories 
         end
     end
     for item in $opts
-        echo $item
+        if test "$item" = "<FILE>" || test "$item" = "<PATH>" || test "$item" = "<FILE>..." || test "$item" = "<PATH>..."
+            __fish_complete_path
+        else if test "$item" = "<DIR>" || test "$item" = "<DIR>..."
+            __fish_complete_directories 
+        else
+            echo $item
+        end
     end
 end
 

--- a/completions/argc.ps1
+++ b/completions/argc.ps1
@@ -27,6 +27,10 @@ $_argc_completion = {
     $comps = (argc --compgen "$argcfile" "$cmds" 2>$null)
     if ($comps -match '^`[^` ]+`$') {
         $comps = (& "$argcfile" $comps.Substring(1, $comps.Length - 2) 2>$null)
+    } elseif ($comps -eq "<FILE>" -or $comps -eq "<PATH>" -or $comps -eq "<FILE>..." -or $comps -eq "<PATH>...") {
+        $comps = ("")
+    } elseif ($comps -eq "<DIR>" -or $comps -eq "<DIR>...") {
+        $comps = ("")
     }
     $comps -split "`n" | 
         Where-Object { $_ -like "$wordToComplete*" } |

--- a/completions/argc.ps1
+++ b/completions/argc.ps1
@@ -14,19 +14,21 @@ $_argc_completion = {
             return;
         }
     }
-    if ($wordToComplete) {
-        $cmds = $commandAst.CommandElements[1..($commandAst.CommandElements.Count - 2)]
+    if ($wordToComplete.ToString() -eq "") {
+        $tail = " "
     } else {
-        $cmds = $commandAst.CommandElements[1..($commandAst.CommandElements.Count - 1)]
+        $tail = ""
     }
-    $comps = (argc --compgen "$argcfile" $cmds 2>$null)
-    $__argc_compgen_cmd="__argc_compgen_cmd:"
-    if ($comps.StartsWith($__argc_compgen_cmd)) {
-        $comps = $comps.Substring($__argc_compgen_cmd.Length)
-        $comps = (& "$argcfile" $comps 2>$null)
-        $comps = $comps.Trim()
+    if ($commandAst.CommandElements.Count -gt 1) {
+        $cmds = ($commandAst.CommandElements[1..($commandAst.CommandElements.Count - 1)] -join " ") + $tail
+    } else {
+        $cmds = $tail
     }
-    $comps -split " " | 
+    $comps = (argc --compgen "$argcfile" "$cmds" 2>$null)
+    if ($comps -match '^`[^` ]+`$') {
+        $comps = (& "$argcfile" $comps.Substring(1, $comps.Length - 2) 2>$null)
+    }
+    $comps -split "`n" | 
         Where-Object { $_ -like "$wordToComplete*" } |
         ForEach-Object { 
             if ($_.StartsWith("-")) {

--- a/completions/argc.zsh
+++ b/completions/argc.zsh
@@ -7,16 +7,22 @@ ARGC_SCRIPTS=( mycmd1 mycmd2 )
 
 _argc_completion()
 {
-    local argcfile values
+    local argcfile line opts
     argcfile=$(which $words[1])
+    line="${words[2,-1]}"
     if [[ $? -ne 0 ]]; then
         return 0
     fi
-    values=( $(argc --compgen "$argcfile" $words[2,-2] 2>/dev/null) )
-    if [[ "$values" = __argc_compgen_cmd:* ]]; then
-        values=( $(bash "$argcfile" ${values#__argc_compgen_cmd:} 2>/dev/null) )
+    IFS=$'\n'
+    opts=( $(argc --compgen "$argcfile" "$line" 2>/dev/null) )
+    if [[ ${#opts[@]} == 0 ]]; then
+        return 0
+    elif [[ ${#opts[@]} == 1 ]]; then
+        if [[ "${opts[1]}" == \`*\` ]]; then
+            opts=( $(bash "$argcfile" "${opts:1:-1}" 2>/dev/null) )
+        fi
     fi
-    compadd -- $values[@]
+    compadd -- $opts[@]
     return 0
 }
 

--- a/completions/argc.zsh
+++ b/completions/argc.zsh
@@ -7,7 +7,7 @@ ARGC_SCRIPTS=( mycmd1 mycmd2 )
 
 _argc_completion()
 {
-    local argcfile line opts
+    local argcfile line opts opts2
     argcfile=$(which $words[1])
     line="${words[2,-1]}"
     if [[ $? -ne 0 ]]; then
@@ -20,17 +20,21 @@ _argc_completion()
     elif [[ ${#opts[@]} == 1 ]]; then
         if [[ "${opts[1]}" == \`*\` ]]; then
             opts=( $(bash "$argcfile" "${opts:1:-1}" 2>/dev/null) )
-        elif [[ "${opts[1]}" == "<FILE>" ]] || [[ "${opts[1]}" == "<PATH>" ]] || [[ "${opts[1]}" == "<FILE>..." ]] || [[ "${opts[1]}" == "<PATH>..." ]]; then
-            opts=()
-            _path_files
-        elif [[ "${opts[1]}" == "<DIR>" ]] || [[ "${opts[1]}" == "<DIR>..." ]]; then
-            opts=()
-            _path_files -/
         fi
     fi
-    
-    if [[ ${#opts[@]} -gt 0 ]]; then
-        compadd -- $opts[@]
+    opts2=()
+    for item in "${opts[@]}"; do
+        if [[ "$item" == "<FILE>" ]] || [[ "$item" == "<PATH>" ]] || [[ "$item" == "<FILE>..." ]] || [[ "$item" == "<PATH>..." ]]; then
+            _path_files
+        elif [[ "$item" == "<DIR>" ]] || [[ "$item" == "<DIR>..." ]]; then
+            _path_files -/
+        else
+            opts2+=("$item")
+        fi
+    done
+
+    if [[ ${#opts2[@]} -gt 0 ]]; then
+        compadd -- $opts2[@]
     fi
 }
 

--- a/completions/argc.zsh
+++ b/completions/argc.zsh
@@ -20,10 +20,18 @@ _argc_completion()
     elif [[ ${#opts[@]} == 1 ]]; then
         if [[ "${opts[1]}" == \`*\` ]]; then
             opts=( $(bash "$argcfile" "${opts:1:-1}" 2>/dev/null) )
+        elif [[ "${opts[1]}" == "<FILE>" ]] || [[ "${opts[1]}" == "<PATH>" ]] || [[ "${opts[1]}" == "<FILE>..." ]] || [[ "${opts[1]}" == "<PATH>..." ]]; then
+            opts=()
+            _path_files
+        elif [[ "${opts[1]}" == "<DIR>" ]] || [[ "${opts[1]}" == "<DIR>..." ]]; then
+            opts=()
+            _path_files -/
         fi
     fi
-    compadd -- $opts[@]
-    return 0
+    
+    if [[ ${#opts[@]} -gt 0 ]]; then
+        compadd -- $opts[@]
+    fi
 }
 
 compdef _argc_completion ${ARGC_SCRIPTS[@]}

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -178,8 +178,9 @@ impl Completion {
                         if index == len - 1 {
                             if !arg_has_value && comp_type == CompType::Any {
                                 comp_type = CompType::OptionValue;
-                                option_complete_values =
-                                    Some(generate_by_choices_or_name(value_name, choices))
+                                option_complete_values = Some(generate_by_choices_or_name(
+                                    value_name, choices, *multiple,
+                                ))
                             }
                             break;
                         }
@@ -187,8 +188,9 @@ impl Completion {
                             index += 1;
                             if index == len - 1 && comp_type == CompType::CommandOrPositional {
                                 comp_type = CompType::OptionValue;
-                                option_complete_values =
-                                    Some(generate_by_choices_or_name(value_name, choices));
+                                option_complete_values = Some(generate_by_choices_or_name(
+                                    value_name, choices, *multiple,
+                                ));
                                 break;
                             }
                         }
@@ -272,11 +274,11 @@ fn add_positional_to_output(
     if positional_index >= positional_len {
         if let Some((name, choices, multiple)) = positionals.last() {
             if *multiple {
-                output.extend(generate_by_choices_or_name(name, choices));
+                output.extend(generate_by_choices_or_name(name, choices, *multiple));
             }
         }
-    } else if let Some((name, choices, _)) = positionals.get(positional_index) {
-        output.extend(generate_by_choices_or_name(name, choices));
+    } else if let Some((name, choices, multiple)) = positionals.get(positional_index) {
+        output.extend(generate_by_choices_or_name(name, choices, *multiple));
     }
 }
 
@@ -320,14 +322,23 @@ fn parse_choices_or_fn(
     }
 }
 
-fn generate_by_choices_or_name(value_name: &str, choices: &Option<ChoicesType>) -> Vec<String> {
+fn generate_by_choices_or_name(
+    value_name: &str,
+    choices: &Option<ChoicesType>,
+    multiple: bool,
+) -> Vec<String> {
     if let Some(choices) = choices {
         match choices {
             Either::Left(choices) => choices.to_vec(),
             Either::Right(choices_fn) => vec![choices_fn.to_string()],
         }
     } else {
-        vec![format!("<{}>", value_name)]
+        let value = if multiple {
+            format!("<{}>...", value_name)
+        } else {
+            format!("<{}>", value_name)
+        };
+        vec![value]
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,9 @@ USAGE:{usage}"#,
     if matches.get_flag("compgen") {
         let (source, cmd_args) = parse_script_args(&script_args)?;
         let cmd_args: Vec<&str> = cmd_args.iter().map(|v| v.as_str()).collect();
-        print!("{}", argc::compgen(&source, &cmd_args)?.join(" "))
+        let line = if cmd_args.len() == 1 { "" } else { cmd_args[1] };
+        let candicates = argc::compgen(&source, line)?;
+        candicates.into_iter().for_each(|v| println!("{v}"));
     } else {
         let (source, cmd_args) = parse_script_args(&script_args)?;
         let cmd_args: Vec<&str> = cmd_args.iter().map(|v| v.as_str()).collect();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use convert_case::{Boundary, Converter, Pattern};
+use std::{fmt, mem};
 
 /// Transform into upper case string with an underscore between words. `foo-bar` => `FOO-BAR`
 pub fn to_cobol_case(value: &str) -> String {
@@ -41,6 +42,143 @@ pub fn is_default_value_terminate(c: char) -> bool {
     c.is_whitespace()
 }
 
+/// An error returned when shell parsing fails.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ParseError;
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("missing closing quote")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {}
+
+pub enum State {
+    /// Within a delimiter.
+    Delimiter,
+    /// After backslash, but before starting word.
+    Backslash,
+    /// Within an unquoted word.
+    Unquoted,
+    /// After backslash in an unquoted word.
+    UnquotedBackslash,
+    /// Within a single quoted word.
+    SingleQuoted,
+    /// Within a double quoted word.
+    DoubleQuoted,
+    /// After backslash inside a double quoted word.
+    DoubleQuotedBackslash,
+    /// Inside a comment.
+    Comment,
+}
+
+pub fn split_shell_words(s: &str) -> Result<Vec<String>, ParseError> {
+    use State::*;
+
+    let mut words = Vec::new();
+    let mut word = String::new();
+    let mut chars = s.chars();
+    let mut state = Delimiter;
+
+    loop {
+        let c = chars.next();
+        state = match state {
+            Delimiter => match c {
+                None => break,
+                Some('\'') => SingleQuoted,
+                Some('\"') => DoubleQuoted,
+                Some('\\') => Backslash,
+                Some('\t') | Some(' ') | Some('\n') => Delimiter,
+                Some('#') => Comment,
+                Some(c) => {
+                    word.push(c);
+                    Unquoted
+                }
+            },
+            Backslash => match c {
+                None => {
+                    word.push('\\');
+                    words.push(mem::take(&mut word));
+                    break;
+                }
+                Some('\n') => Delimiter,
+                Some(c) => {
+                    word.push(c);
+                    Unquoted
+                }
+            },
+            Unquoted => match c {
+                None => {
+                    words.push(mem::take(&mut word));
+                    break;
+                }
+                Some('\'') => SingleQuoted,
+                Some('\"') => DoubleQuoted,
+                Some('\\') => UnquotedBackslash,
+                Some('\t') | Some(' ') | Some('\n') => {
+                    words.push(mem::take(&mut word));
+                    Delimiter
+                }
+                Some(c) => {
+                    word.push(c);
+                    Unquoted
+                }
+            },
+            UnquotedBackslash => match c {
+                None => {
+                    word.push('\\');
+                    words.push(mem::take(&mut word));
+                    break;
+                }
+                Some('\n') => Unquoted,
+                Some(c) => {
+                    word.push(c);
+                    Unquoted
+                }
+            },
+            SingleQuoted => match c {
+                None => return Err(ParseError),
+                Some('\'') => Unquoted,
+                Some(c) => {
+                    word.push(c);
+                    SingleQuoted
+                }
+            },
+            DoubleQuoted => match c {
+                None => return Err(ParseError),
+                Some('\"') => Unquoted,
+                Some('\\') => DoubleQuotedBackslash,
+                Some(c) => {
+                    word.push(c);
+                    DoubleQuoted
+                }
+            },
+            DoubleQuotedBackslash => match c {
+                None => return Err(ParseError),
+                Some('\n') => DoubleQuoted,
+                Some(c @ '$') | Some(c @ '`') | Some(c @ '"') | Some(c @ '\\') => {
+                    word.push(c);
+                    DoubleQuoted
+                }
+                Some(c) => {
+                    word.push('\\');
+                    word.push(c);
+                    DoubleQuoted
+                }
+            },
+            Comment => match c {
+                None => break,
+                Some('\n') => Delimiter,
+                Some(_) => Comment,
+            },
+        }
+    }
+
+    Ok(words)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,5 +188,21 @@ mod tests {
         assert_eq!("FOO-BAR".to_string(), to_cobol_case("fooBar"));
         assert_eq!("FOO-BAR".to_string(), to_cobol_case("foo-bar"));
         assert_eq!("FOO1".to_string(), to_cobol_case("foo1"));
+    }
+
+    #[test]
+    fn test_split_shell_words() {
+        assert_eq!(
+            split_shell_words("abc def").unwrap(),
+            vec!["abc".to_string(), "def".to_string()]
+        );
+        assert_eq!(
+            split_shell_words("abc \"def ghi\"").unwrap(),
+            vec!["abc".to_string(), "def ghi".to_string()]
+        );
+        assert_eq!(
+            split_shell_words("abc 'def ghi'").unwrap(),
+            vec!["abc".to_string(), "def ghi".to_string()]
+        );
     }
 }

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -12,58 +12,65 @@ bar() { :; }
 
 #[test]
 fn test_compgen() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog"]);
+    snapshot_compgen!(SPEC_SCRIPT, "");
 }
 
 #[test]
 fn test_compgen_help() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "help"]);
+    snapshot_compgen!(SPEC_SCRIPT, "help");
 }
 
 #[test]
 fn test_compgen_subcommand() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_option_names"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names ");
 }
 
 #[test]
 fn test_compgen_option_choices() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_option_names", "--opt7"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names --opt7 ");
+}
+
+#[test]
+fn test_compgen_option_choices2() {
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names --opt7 a");
+}
+
+#[test]
+fn test_compgen_option_choices3() {
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names --opt7 a ");
 }
 
 #[test]
 fn test_compgen_positional() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_positional_requires"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_positional_requires ");
 }
 
 #[test]
 fn test_compgen_positional_arg() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_positional_requires", "arg1"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_positional_requires arg1 ");
 }
 
 #[test]
 fn test_compgen_positional_arg2() {
-    snapshot_compgen!(
-        SPEC_SCRIPT,
-        &["prog", "cmd_positional_requires", "arg1", "arg2"]
-    );
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_positional_requires arg1 arg2 ");
 }
 
 #[test]
 fn test_compgen_positional_choices() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_positional_with_choices"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_positional_with_choices ");
 }
 
 #[test]
 fn test_compgen_help_tag() {
-    snapshot_compgen!(HELP_TAG_SCRIPT, &["prog"]);
+    snapshot_compgen!(HELP_TAG_SCRIPT, "");
 }
 
 #[test]
 fn test_compgen_help_tag2() {
-    snapshot_compgen!(HELP_TAG_SCRIPT, &["prog", "help"]);
+    snapshot_compgen!(HELP_TAG_SCRIPT, "help");
 }
 
 #[test]
 fn test_compgen_choice_fn() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_option_names", "--op11"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names --op11 ");
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -70,7 +70,6 @@ macro_rules! snapshot_compgen {
             Err(stderr) => (String::new(), stderr.to_string()),
         };
 
-        let args = $args.join(" ");
         let output = format!(
             r###"RUN
 {}
@@ -81,7 +80,7 @@ STDOUT
 STDERR
 {}
 "###,
-            args, stdout, stderr
+            $args, stdout, stderr
         );
         insta::assert_snapshot!(output);
     };

--- a/tests/snapshots/integration__compgen__compgen.snap
+++ b/tests/snapshots/integration__compgen__compgen.snap
@@ -3,7 +3,7 @@ source: tests/compgen.rs
 expression: output
 ---
 RUN
-prog
+
 
 STDOUT
 cmd_preferred cmd_omitted cmd_option_names cmd_option_formats cmd_option_quotes cmd_flag_formats cmd_positional_only cmd_positional_requires cmd_positional_with_choices cmd_positional_with_default cmd_positional_with_default_fn cmd_positional_with_choices_and_default cmd_positional_with_choices_fn cmd_positional_with_choices_and_required cmd_positional_with_choices_fn_and_required cmd_without_any_arg cmd_alias a alias cmd_with_hyphens

--- a/tests/snapshots/integration__compgen__compgen_help.snap
+++ b/tests/snapshots/integration__compgen__compgen_help.snap
@@ -3,7 +3,7 @@ source: tests/compgen.rs
 expression: output
 ---
 RUN
-prog help
+help
 
 STDOUT
 cmd_preferred cmd_omitted cmd_option_names cmd_option_formats cmd_option_quotes cmd_flag_formats cmd_positional_only cmd_positional_requires cmd_positional_with_choices cmd_positional_with_default cmd_positional_with_default_fn cmd_positional_with_choices_and_default cmd_positional_with_choices_fn cmd_positional_with_choices_and_required cmd_positional_with_choices_fn_and_required cmd_without_any_arg cmd_alias a alias cmd_with_hyphens

--- a/tests/snapshots/integration__compgen__compgen_help_tag.snap
+++ b/tests/snapshots/integration__compgen__compgen_help_tag.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 58
 expression: output
 ---
 RUN
-prog
+
 
 STDOUT
 foo bar help

--- a/tests/snapshots/integration__compgen__compgen_help_tag2.snap
+++ b/tests/snapshots/integration__compgen__compgen_help_tag2.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 63
 expression: output
 ---
 RUN
-prog help
+help
 
 STDOUT
 foo bar

--- a/tests/snapshots/integration__compgen__compgen_option_choices.snap
+++ b/tests/snapshots/integration__compgen__compgen_option_choices.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 30
 expression: output
 ---
 RUN
-prog cmd_option_names --opt7
+cmd_option_names --opt7 
 
 STDOUT
 a b c

--- a/tests/snapshots/integration__compgen__compgen_option_choices2.snap
+++ b/tests/snapshots/integration__compgen__compgen_option_choices2.snap
@@ -3,10 +3,10 @@ source: tests/compgen.rs
 expression: output
 ---
 RUN
-cmd_option_names --op11 
+cmd_option_names --opt7 a
 
 STDOUT
-`_fn_bars`
+a b c
 
 STDERR
 

--- a/tests/snapshots/integration__compgen__compgen_option_choices3.snap
+++ b/tests/snapshots/integration__compgen__compgen_option_choices3.snap
@@ -1,0 +1,13 @@
+---
+source: tests/compgen.rs
+expression: output
+---
+RUN
+cmd_option_names --opt7 a 
+
+STDOUT
+--opt1 --opt2 --opt3 --opt4 --opt5 --opt6 --opt8 --opt9 --op10 --op11
+
+STDERR
+
+

--- a/tests/snapshots/integration__compgen__compgen_positional.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 35
 expression: output
 ---
 RUN
-prog cmd_positional_requires
+cmd_positional_requires 
 
 STDOUT
 <ARG1>

--- a/tests/snapshots/integration__compgen__compgen_positional_arg.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional_arg.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/compgen.rs
-assertion_line: 40
 expression: output
 ---
 RUN
-prog cmd_positional_requires arg1
+cmd_positional_requires arg1 
 
 STDOUT
-<ARG2>...
+<ARG2>
 
 STDERR
 

--- a/tests/snapshots/integration__compgen__compgen_positional_arg.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional_arg.snap
@@ -6,7 +6,7 @@ RUN
 cmd_positional_requires arg1 
 
 STDOUT
-<ARG2>
+<ARG2>...
 
 STDERR
 

--- a/tests/snapshots/integration__compgen__compgen_positional_arg2.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional_arg2.snap
@@ -6,7 +6,7 @@ RUN
 cmd_positional_requires arg1 arg2 
 
 STDOUT
-<ARG2>
+<ARG2>...
 
 STDERR
 

--- a/tests/snapshots/integration__compgen__compgen_positional_arg2.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional_arg2.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/compgen.rs
-assertion_line: 45
 expression: output
 ---
 RUN
-prog cmd_positional_requires arg1 arg2
+cmd_positional_requires arg1 arg2 
 
 STDOUT
-<ARG2>...
+<ARG2>
 
 STDERR
 

--- a/tests/snapshots/integration__compgen__compgen_positional_choices.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional_choices.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 53
 expression: output
 ---
 RUN
-prog cmd_positional_with_choices
+cmd_positional_with_choices 
 
 STDOUT
 a b

--- a/tests/snapshots/integration__compgen__compgen_subcommand.snap
+++ b/tests/snapshots/integration__compgen__compgen_subcommand.snap
@@ -3,7 +3,7 @@ source: tests/compgen.rs
 expression: output
 ---
 RUN
-prog cmd_option_names
+cmd_option_names 
 
 STDOUT
 --opt1 --opt2 --opt3 --opt4 --opt5 --opt6 --opt7 --opt8 --opt9 --op10 --op11

--- a/tests/snapshots/integration__spec_test__spec_cmd_preferred_exec.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_preferred_exec.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec_test.rs
-assertion_line: 50
 expression: output
 ---
 RUN


### PR DESCRIPTION
Two difference:

1. `--compgen` accept two arguments only, one for sript path, one for command line buffer.

`argc --compgen ./mycmd1 download` => `argc --compgen ./mycmd1 'download '`

The space in the end is very import. Having space or not having space will generate completely different results. After this PR merged, argc can recognize this difference.

2. Candidates are separated by `\n`, not by ` `