### PR TITLE
feat: enhance choice and choice_fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ COMMANDS:
 ### @arg
 
 ```
-@arg <name>[modifier] [value notation] [help string]
+@arg <name>[modifier|default|modifer+choices] [value notation] [help string]
 ```
 
 Define a positional argument.
@@ -114,21 +114,20 @@ Define a positional argument.
 # @arg arg1            A positional argument
 # @arg arg2!           A required positional argument
 # @arg arg3 <PATH>     A positional argument with value notation
-# @arg arg4*           A positional argument support multiple values
-# @arg arg5+           A required positional argument support multiple values
+# @arg arg4*           A positional argument with multiple values
+# @arg arg5+           A required positional argument with multiple values
 # @arg arg6=a          A positional argument with default value
 # @arg arg7=`_fn`      A positional argument with default value from fn
 # @arg arg8[a|b]       A positional argument with choices
 # @arg arg9[`_fn`]     A positional argument with choices from fn
 # @arg arg10[=a|b]     A positional argument with choices and default value
-# @arg arg11![a|b]     A required positional argument with choices
-# @arg arg12![`_fn`]   A required positional argument with choices from fn
+# @arg arg11*[a|b]     A positional argument with choices and multiple values
 ```
 
 ### @option
 
 ```
-@option [short] <long>[modifier] [value notation] [help string]
+@option [short] <long>[modifier|default|modifier+choices] [value notation] [help string]
 ```
 
 Define a option.
@@ -145,15 +144,13 @@ Define a option.
 # @option    --opt9[a|b]            A option with choices
 # @option    --opt10[`_fn`]         A option with choices from fn
 # @option    --opt11[=a|b]          A option with choices and default value
-# @option    --opt12![a|b]          A required option with choices
-# @option    --opt13![`_fn`]        A required option with choices from fn
-# @option -b --opt14 <PATH>         A option with short alias and value notation
+# @option    --opt12*[a|b]          A option with choices and multiple values
 ```
 
 ### @flag
 
 ```
-@flag [short] <long> [help string]
+@flag [short] <long>[*] [help string]
 ```
 
 Define a flag. A flag is an option of boolean type, and is always false by default (e.g. --verbose, --quiet, --all, --long, etc).

--- a/src/param.rs
+++ b/src/param.rs
@@ -431,7 +431,7 @@ fn render_name(
 ) -> String {
     let mut name = name.to_string();
     if let Some(choices) = choices {
-        if let Some(ch) = get_mark(required, multiple) {
+        if let Some(ch) = get_modifer(required, multiple) {
             name.push(ch)
         }
         let mut prefix = String::new();
@@ -451,7 +451,7 @@ fn render_name(
         let choices_value = format!("[{}{}]", prefix, values.join("|"));
         name.push_str(&choices_value);
     } else if let Some(choices_fn) = choices_fn {
-        if let Some(ch) = get_mark(required, multiple) {
+        if let Some(ch) = get_modifer(required, multiple) {
             name.push(ch)
         }
         let _ = write!(name, "[`{}`]", choices_fn);
@@ -464,13 +464,13 @@ fn render_name(
         let _ = write!(name, "={}", value);
     } else if let Some(default_fn) = default_fn {
         let _ = write!(name, "=`{}`", default_fn);
-    } else if let Some(ch) = get_mark(required, multiple) {
+    } else if let Some(ch) = get_modifer(required, multiple) {
         name.push(ch)
     }
     name
 }
 
-fn get_mark(required: bool, multiple: bool) -> Option<char> {
+fn get_modifer(required: bool, multiple: bool) -> Option<char> {
     match (required, multiple) {
         (true, true) => Some('+'),
         (true, false) => Some('!'),

--- a/src/param.rs
+++ b/src/param.rs
@@ -431,8 +431,8 @@ fn render_name(
 ) -> String {
     let mut name = name.to_string();
     if let Some(choices) = choices {
-        if required {
-            name.push('!')
+        if let Some(ch) = get_mark(required, multiple) {
+            name.push(ch)
         }
         let mut prefix = String::new();
         if default.is_some() {
@@ -451,8 +451,8 @@ fn render_name(
         let choices_value = format!("[{}{}]", prefix, values.join("|"));
         name.push_str(&choices_value);
     } else if let Some(choices_fn) = choices_fn {
-        if required {
-            name.push('!')
+        if let Some(ch) = get_mark(required, multiple) {
+            name.push(ch)
         }
         let _ = write!(name, "[`{}`]", choices_fn);
     } else if let Some(default) = default {
@@ -464,15 +464,19 @@ fn render_name(
         let _ = write!(name, "={}", value);
     } else if let Some(default_fn) = default_fn {
         let _ = write!(name, "=`{}`", default_fn);
-    } else if let Some(ch) = match (required, multiple) {
+    } else if let Some(ch) = get_mark(required, multiple) {
+        name.push(ch)
+    }
+    name
+}
+
+fn get_mark(required: bool, multiple: bool) -> Option<char> {
+    match (required, multiple) {
         (true, true) => Some('+'),
         (true, false) => Some('!'),
         (false, true) => Some('*'),
         (false, false) => None,
-    } {
-        name.push(ch)
     }
-    name
 }
 
 fn new_arg(name: &str, summary: &str) -> Arg {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -192,12 +192,12 @@ fn parse_with_long_option_param(input: &str) -> nom::IResult<&str, OptionParam> 
             preceded(
                 pair(space0, tag("--")),
                 alt((
-                    parse_param_mark_choices_default,
-                    parse_param_mark_choices_fn,
-                    parse_param_mark_choices,
+                    parse_param_modifer_choices_default,
+                    parse_param_modifer_choices_fn,
+                    parse_param_modifer_choices,
                     parse_param_assign_fn,
                     parse_param_assign,
-                    parse_param_mark,
+                    parse_param_modifer,
                 )),
             ),
             parse_value_notation,
@@ -218,12 +218,12 @@ fn parse_no_long_option_param(input: &str) -> nom::IResult<&str, OptionParam> {
                 preceded(
                     verify_single_char,
                     alt((
-                        parse_param_mark_choices_default,
-                        parse_param_mark_choices_fn,
-                        parse_param_mark_choices,
+                        parse_param_modifer_choices_default,
+                        parse_param_modifer_choices_fn,
+                        parse_param_modifer_choices,
                         parse_param_assign_fn,
                         parse_param_assign,
-                        parse_param_mark,
+                        parse_param_modifer,
                     )),
                 ),
             ),
@@ -242,12 +242,12 @@ fn parse_positional_param(input: &str) -> nom::IResult<&str, PositionalParam> {
     map(
         tuple((
             alt((
-                parse_param_mark_choices_default,
-                parse_param_mark_choices_fn,
-                parse_param_mark_choices,
+                parse_param_modifer_choices_default,
+                parse_param_modifer_choices_fn,
+                parse_param_modifer_choices,
                 parse_param_assign_fn,
                 parse_param_assign,
-                parse_param_mark,
+                parse_param_modifer,
             )),
             parse_value_notation,
             parse_tail,
@@ -301,7 +301,7 @@ fn parse_param_multiple(input: &str) -> nom::IResult<&str, ParamData> {
 }
 
 // Parse `str!` `str*` `str+` `str`
-fn parse_param_mark(input: &str) -> nom::IResult<&str, ParamData> {
+fn parse_param_modifer(input: &str) -> nom::IResult<&str, ParamData> {
     alt((
         map(terminated(parse_param_name, tag("!")), |mut arg| {
             arg.required = true;
@@ -342,10 +342,10 @@ fn parse_param_assign_fn(input: &str) -> nom::IResult<&str, ParamData> {
     )(input)
 }
 
-fn parse_param_mark_choices_default(input: &str) -> nom::IResult<&str, ParamData> {
+fn parse_param_modifer_choices_default(input: &str) -> nom::IResult<&str, ParamData> {
     map(
         pair(
-            parse_param_mark,
+            parse_param_modifer,
             delimited(char('['), parse_choices_default, char(']')),
         ),
         |(mut arg, (choices, default))| {
@@ -357,10 +357,10 @@ fn parse_param_mark_choices_default(input: &str) -> nom::IResult<&str, ParamData
     )(input)
 }
 
-fn parse_param_mark_choices(input: &str) -> nom::IResult<&str, ParamData> {
+fn parse_param_modifer_choices(input: &str) -> nom::IResult<&str, ParamData> {
     map(
         pair(
-            parse_param_mark,
+            parse_param_modifer,
             delimited(char('['), parse_choices, char(']')),
         ),
         |(mut arg, choices)| {
@@ -370,10 +370,10 @@ fn parse_param_mark_choices(input: &str) -> nom::IResult<&str, ParamData> {
     )(input)
 }
 
-fn parse_param_mark_choices_fn(input: &str) -> nom::IResult<&str, ParamData> {
+fn parse_param_modifer_choices_fn(input: &str) -> nom::IResult<&str, ParamData> {
     map(
         pair(
-            parse_param_mark,
+            parse_param_modifer,
             delimited(char('['), parse_value_fn, char(']')),
         ),
         |(mut arg, choices_fn)| {


### PR DESCRIPTION
choice and choice_fn can combine with any modifer
```
# @option --foo[a|b]
# @option --foo![a|b]
# @option --foo+[a|b]
# @option --foo*[a|b]
# @option --foo[=a|b]
# @option --foo![=a|b]
# @option --foo+[=a|b]
# @option --foo*[=a|b]
# @option --foo[`_foo`]
# @option --foo![`_foo`]
# @option --foo+[`_foo`]
# @option --foo*[`_foo`]
# @option foo[a|b]
# @option foo![a|b]
# @option foo+[a|b]
# @option foo*[a|b]
```