### PR TITLE
feat: abandon dynamic compgen fn

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,4 @@
 use crate::argc_value::ArgcValue;
-use crate::completion::DYNAMIC_COMPGEN_FN;
 use crate::param::{Param, ParamNames, PositionalParam, EXTRA_ARGS};
 use crate::parser::{parse, Event, EventData, EventScope, Position};
 use crate::utils::{argmap, escape_shell_words, split_shell_words};
@@ -149,8 +148,6 @@ impl Cli {
                                 }
                             }
                         }
-                    } else if name == DYNAMIC_COMPGEN_FN {
-                        root_data.borrow_mut().dynamic_compgen = true;
                     }
                     root_data.borrow_mut().scope = EventScope::FnEnd;
                 }
@@ -381,7 +378,6 @@ impl Cli {
 struct RootData {
     scope: EventScope,
     fns: HashMap<String, Position>,
-    dynamic_compgen: bool,
     default_fns: Vec<(String, Position)>,
     choices_fns: Vec<(String, Position)>,
 }
@@ -416,7 +412,6 @@ impl RootData {
     }
 
     fn exist_param_fn(&self, name: &str) -> bool {
-        (self.dynamic_compgen && name == DYNAMIC_COMPGEN_FN)
-            || self.choices_fns.iter().any(|(v, _)| v == name)
+        self.choices_fns.iter().any(|(v, _)| v == name)
     }
 }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -18,8 +18,6 @@ type ChoicesType = Either<Vec<String>, String>;
 type OptionMapType = (Option<String>, Vec<String>, Option<ChoicesType>, bool);
 type PositionalItemType = (String, Option<ChoicesType>, bool);
 
-pub(crate) const DYNAMIC_COMPGEN_FN: &str = "_compgen";
-
 #[derive(Default)]
 pub struct Completion {
     name: Option<String>,
@@ -140,8 +138,6 @@ impl Completion {
                             }
                         }
                         root_data.borrow_mut().scope = EventScope::FnEnd;
-                    } else if name == DYNAMIC_COMPGEN_FN {
-                        root_data.borrow_mut().dynamic_compgen = true;
                     }
                 }
                 _ => {}
@@ -306,9 +302,6 @@ impl Completion {
                 add_positional_to_output(&mut output, positional_index, &comp.positionals);
             }
         }
-        if self.root.borrow().dynamic_compgen && output.iter().all(|v| !v.starts_with('`')) {
-            output.push(format!("`{}`", DYNAMIC_COMPGEN_FN));
-        }
         Ok(output)
     }
 
@@ -370,7 +363,6 @@ fn add_positional_to_output(
 #[derive(Default)]
 struct RootData {
     scope: EventScope,
-    dynamic_compgen: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -10,11 +10,6 @@ foo() { :; }
 bar() { :; }
 "#;
 
-const DYNAMIC_COMPGEN_SCRIPT: &str = r#"
-# @option --foo
-_compgen() { :; }
-"#;
-
 #[test]
 fn test_compgen() {
     snapshot_compgen!(SPEC_SCRIPT, "");
@@ -93,11 +88,6 @@ fn test_compgen_nested_command_subcommand() {
 #[test]
 fn test_compgen_nested_command_subcommand2() {
     snapshot_compgen!(SPEC_SCRIPT, "cmd_nested_command fo");
-}
-
-#[test]
-fn test_dynamic_compgen() {
-    snapshot_compgen!(DYNAMIC_COMPGEN_SCRIPT, "");
 }
 
 #[test]


### PR DESCRIPTION
This revert #61 . We don't need this.
For complete dynamic subcmd like yarn or cargo.
We can simple define a positional arg choice fn to achieve the same effect.