### PR TITLE
fix: throw error if @cmd miss fn

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,9 @@ impl Cli {
                     cmd.help = Some(value);
                 }
                 EventData::Cmd(value) => {
+                    if root_cmd.root.borrow().scope == EventScope::CmdStart {
+                        bail!("@cmd(line {}) is unexpected, miss function?", position)
+                    }
                     root_data.borrow_mut().scope = EventScope::CmdStart;
                     let mut subcmd = root_cmd.create_subcommand();
                     if !value.is_empty() {

--- a/tests/fail_test.rs
+++ b/tests/fail_test.rs
@@ -167,3 +167,16 @@ fn test_arg_miss_choice_fn() {
     "###;
     fatal!(script, &["prog"], "_fn(line 2) is missing");
 }
+
+#[test]
+fn test_cmd_miss_fn() {
+    let script = r###"
+# @cmd
+# @cmd
+    "###;
+    fatal!(
+        script,
+        &["prog"],
+        "@cmd(line 3) is unexpected, miss function?"
+    );
+}


### PR DESCRIPTION
```
# @cmd
# @cmd
```

should throw 
```
@cmd(line 2) is unexpected, miss function?"
```