### PR TITLE
feat: validate param with choices fn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,8 @@ jobs:
 
     - uses: Swatinem/rust-cache@v1
 
+    - run: cargo install --path .
+
     - name: Test
       run: cargo test --all
 

--- a/src/bin/argc/main.rs
+++ b/src/bin/argc/main.rs
@@ -39,7 +39,7 @@ fn run() -> Result<i32> {
         match argc_cmd {
             "--argc-eval" => {
                 let (source, cmd_args) = parse_script_args(&args[2..])?;
-                let values = argc::eval(&source, &cmd_args)?;
+                let values = argc::eval(Some(&args[2]), &source, &cmd_args)?;
                 println!("{}", argc::ArgcValue::to_shell(values))
             }
             "--argc-create" => {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -156,7 +156,9 @@ impl<'a, 'b> Matcher<'a, 'b> {
                     .map(|v| v.trim().to_string())
                     .filter(|v| !v.is_empty())
                     .collect();
-                self.choices_values.insert(fns[i], choices);
+                if !choices.is_empty() {
+                    self.choices_values.insert(fns[i], choices);
+                }
             }
         }
     }

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -132,3 +132,8 @@ fn test_compgen_cmd_single_dash() {
 fn test_compgen_cmd_single_dash2() {
     snapshot_compgen!("cmd_single_dash -f");
 }
+
+#[test]
+fn test_compgen_choice_fns() {
+    snapshot_compgen!("cmd_option_names --op10 ");
+}

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,11 +1,12 @@
 #[macro_export]
 macro_rules! snapshot {
     (
+		$path:expr,
         $source:expr,
         $args:expr
     ) => {
         let args: Vec<String> = $args.iter().map(|v| v.to_string()).collect();
-        let values = argc::eval($source, &args).unwrap();
+        let values = argc::eval($path, $source, &args).unwrap();
         let output = argc::ArgcValue::to_shell(values);
         let args = $args.join(" ");
         let output = format!(
@@ -22,6 +23,14 @@ OUTPUT
 }
 
 #[macro_export]
+macro_rules! snapshot_spec {
+    ($args:expr) => {
+        let (path, source) = crate::fixtures::get_spec();
+        snapshot!(Some(path.as_str()), source.as_str(), $args);
+    };
+}
+
+#[macro_export]
 macro_rules! plain {
     (
         $source:expr,
@@ -29,7 +38,7 @@ macro_rules! plain {
 		$output:expr
     ) => {
         let args: Vec<String> = $args.iter().map(|v| v.to_string()).collect();
-        let values = argc::eval($source, &args).unwrap();
+        let values = argc::eval(None, $source, &args).unwrap();
         let output = argc::ArgcValue::to_shell(values);
         assert_eq!(output, $output);
     };
@@ -43,7 +52,7 @@ macro_rules! fatal {
         $err:expr
     ) => {
         let args: Vec<String> = $args.iter().map(|v| v.to_string()).collect();
-        let err = argc::eval($source, &args).unwrap_err();
+        let err = argc::eval(None, $source, &args).unwrap_err();
         assert_eq!(err.to_string().as_str(), $err);
     };
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -25,7 +25,7 @@ OUTPUT
 #[macro_export]
 macro_rules! snapshot_spec {
     ($args:expr) => {
-        let (path, source) = crate::fixtures::get_spec();
+        let (path, source) = $crate::fixtures::get_spec();
         snapshot!(Some(path.as_str()), source.as_str(), $args);
     };
 }

--- a/tests/main_fn_test.rs
+++ b/tests/main_fn_test.rs
@@ -33,7 +33,7 @@ main() {
 }
     "###;
     plain!(script, &["prog", "cmd"], "cmd");
-    snapshot!(script, &["prog", "-h"]);
+    snapshot!(None, script, &["prog", "-h"]);
 }
 
 #[test]
@@ -48,7 +48,7 @@ cmd() {
 
     "###;
     plain!(script, &["prog", "cmd"], "cmd");
-    snapshot!(script, &["prog"]);
+    snapshot!(None, script, &["prog"]);
 }
 
 #[test]
@@ -62,5 +62,5 @@ cmd() {
 }
 
     "###;
-    snapshot!(script, &["prog", "-h"]);
+    snapshot!(None, script, &["prog", "-h"]);
 }

--- a/tests/param_fn_test.rs
+++ b/tests/param_fn_test.rs
@@ -1,82 +1,59 @@
-use super::SPEC_SCRIPT;
-
 #[test]
 fn test_param_fn_empty() {
-    snapshot!(SPEC_SCRIPT, &["spec", "_fn_args"]);
+    snapshot_spec!(&["spec", "_fn_args"]);
 }
 
 #[test]
 fn test_param_fn_space() {
-    snapshot!(SPEC_SCRIPT, &["spec", "_fn_args", " "]);
+    snapshot_spec!(&["spec", "_fn_args", " "]);
 }
 
 #[test]
 fn test_param_fn_args() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "_fn_args", "cmd_preferred -f -o 4 abc"]
-    );
+    snapshot_spec!(&["spec", "_fn_args", "cmd_preferred -f -o 4 abc"]);
 }
 
 #[test]
 fn test_param_fn_args_dup_flag() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "_fn_args", "cmd_preferred -f -o 4 -f"]
-    );
+    snapshot_spec!(&["spec", "_fn_args", "cmd_preferred -f -o 4 -f"]);
 }
 
 #[test]
 fn test_param_fn_args_dup_option() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "_fn_args", "cmd_preferred -f -o 4 -o 5"]
-    );
+    snapshot_spec!(&["spec", "_fn_args", "cmd_preferred -f -o 4 -o 5"]);
 }
 
 #[test]
 fn test_param_fn_args_dup_dashdash1() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "_fn_args", "cmd_preferred -f -o 4 -- abc"]
-    );
+    snapshot_spec!(&["spec", "_fn_args", "cmd_preferred -f -o 4 -- abc"]);
 }
 
 #[test]
 fn test_param_fn_args_dup_dashdash2() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "_fn_args", "cmd_preferred -f -o 4 abc --"]
-    );
+    snapshot_spec!(&["spec", "_fn_args", "cmd_preferred -f -o 4 abc --"]);
 }
 
 #[test]
 fn test_param_fn_args_dup_dashdash3() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "_fn_args", "cmd_preferred -f -o 4 abc -- def"]
-    );
+    snapshot_spec!(&["spec", "_fn_args", "cmd_preferred -f -o 4 abc -- def"]);
 }
 
 #[test]
 fn test_param_fn_args_incomplete_option() {
-    snapshot!(SPEC_SCRIPT, &["spec", "_fn_args", "cmd_preferred -f -o"]);
+    snapshot_spec!(&["spec", "_fn_args", "cmd_preferred -f -o"]);
 }
 
 #[test]
 fn test_param_fn_args_nontmatch_subcommand() {
-    snapshot!(SPEC_SCRIPT, &["spec", "_fn_args", "cmd_prefer"]);
+    snapshot_spec!(&["spec", "_fn_args", "cmd_prefer"]);
 }
 
 #[test]
 fn test_param_fn_args_unknown_option() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "_fn_args", "cmd_preferred -f -o 4 -x"]
-    );
+    snapshot_spec!(&["spec", "_fn_args", "cmd_preferred -f -o 4 -x"]);
 }
 
 #[test]
 fn test_param_fn_bars() {
-    snapshot!(SPEC_SCRIPT, &["spec", "_fn_bars",]);
+    snapshot_spec!(&["spec", "_fn_bars",]);
 }

--- a/tests/snapshots/integration__compgen__compgen_choice_fns.snap
+++ b/tests/snapshots/integration__compgen__compgen_choice_fns.snap
@@ -1,0 +1,15 @@
+---
+source: tests/compgen.rs
+expression: output
+---
+RUN
+cmd_option_names --op10 
+
+STDOUT
+a1
+a2
+a3
+
+STDERR
+
+

--- a/tests/snapshots/integration__spec_test__spec_cmd_option_names_choices_fn.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_option_names_choices_fn.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec_test.rs
+expression: output
+---
+RUN
+spec cmd_option_names --opt2 v2 --opt4 v4 --opt8 v8 --op11 xyz
+
+OUTPUT
+cat >&2 <<-'EOF' 
+error: invalid value 'v8' for '<OPT8>'
+  [possible values: a, b, c]
+
+For more information, try '--help'.
+
+EOF
+exit 1
+

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_fn.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_fn.snap
@@ -1,0 +1,17 @@
+---
+source: tests/spec_test.rs
+expression: output
+---
+RUN
+spec cmd_positional_with_choices_fn xyz
+
+OUTPUT
+cat >&2 <<-'EOF' 
+error: invalid value 'xyz' for '[ARG]'
+  [possible values: a1, a2, a3]
+
+For more information, try '--help'.
+
+EOF
+exit 1
+

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -1,307 +1,284 @@
-use super::SPEC_SCRIPT;
-
 #[test]
 fn test_spec_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "-h"]);
+    snapshot_spec!(&["spec", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_preferred_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_preferred", "-h"]);
+    snapshot_spec!(&["spec", "cmd_preferred", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_omitted_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_omitted", "-h"]);
+    snapshot_spec!(&["spec", "cmd_omitted", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_option_names_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_option_names", "-h"]);
+    snapshot_spec!(&["spec", "cmd_option_names", "-h"]);
+}
+
+#[test]
+fn test_spec_cmd_option_names_choices_fn() {
+    snapshot_spec!(&[
+        "spec",
+        "cmd_option_names",
+        "--opt2",
+        "v2",
+        "--opt4",
+        "v4",
+        "--opt8",
+        "v8",
+        "--op11",
+        "xyz"
+    ]);
 }
 
 #[test]
 fn test_spec_cmd_option_formats_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_option_formats", "-h"]);
+    snapshot_spec!(&["spec", "cmd_option_formats", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_option_quotes_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_option_quotes", "-h"]);
+    snapshot_spec!(&["spec", "cmd_option_quotes", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_flag_formats_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_flag_formats", "-h"]);
+    snapshot_spec!(&["spec", "cmd_flag_formats", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_flag_formats_count() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_flag_formats", "--foo5", "--foo5", "--foo5"]
-    );
+    snapshot_spec!(&["spec", "cmd_flag_formats", "--foo5", "--foo5", "--foo5"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_only_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_positional_only", "-h"]);
+    snapshot_spec!(&["spec", "cmd_positional_only", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_requires_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_positional_requires", "-h"]);
+    snapshot_spec!(&["spec", "cmd_positional_requires", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_preferred_exec() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_preferred", "-f", "-o", "A", "AB", "C D"]
-    );
+    snapshot_spec!(&["spec", "cmd_preferred", "-f", "-o", "A", "AB", "C D"]);
 }
 
 #[test]
 fn test_spec_cmd_option_names_exec() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &[
-            "spec",
-            "cmd_option_names",
-            "--opt2",
-            "value2",
-            "--opt3",
-            "value3_0",
-            "--opt3",
-            "value3_1",
-            "--opt4",
-            "value4_0",
-            "--opt4",
-            "value4_1",
-            "--opt6",
-            "a",
-            "--opt8",
-            "a",
-            "--op11",
-            "a1"
-        ]
-    );
+    snapshot_spec!(&[
+        "spec",
+        "cmd_option_names",
+        "--opt2",
+        "value2",
+        "--opt3",
+        "value3_0",
+        "--opt3",
+        "value3_1",
+        "--opt4",
+        "value4_0",
+        "--opt4",
+        "value4_1",
+        "--opt6",
+        "a",
+        "--opt8",
+        "a",
+        "--op11",
+        "a1"
+    ]);
 }
 
 #[test]
 fn test_spec_cmd_option_names_exec_eval() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &[
-            "spec",
-            "cmd_option_names",
-            "--opt2",
-            "value2",
-            "--opt3",
-            "value3_0",
-            "--opt3",
-            "value3_1",
-            "--opt4",
-            "value4_0",
-            "--opt4",
-            "value4_1",
-            "--opt6",
-            "a",
-            "--opt8",
-            "a",
-            "--op11",
-            "a1"
-        ]
-    );
+    snapshot_spec!(&[
+        "spec",
+        "cmd_option_names",
+        "--opt2",
+        "value2",
+        "--opt3",
+        "value3_0",
+        "--opt3",
+        "value3_1",
+        "--opt4",
+        "value4_0",
+        "--opt4",
+        "value4_1",
+        "--opt6",
+        "a",
+        "--opt8",
+        "a",
+        "--op11",
+        "a1"
+    ]);
 }
 
 #[test]
 fn test_spec_cmd_positional_with_default() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_positional_with_default", "-h"]);
+    snapshot_spec!(&["spec", "cmd_positional_with_default", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_with_default_exec() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_positional_with_default"]);
+    snapshot_spec!(&["spec", "cmd_positional_with_default"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_with_choices() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_positional_with_choices", "-h"]);
+    snapshot_spec!(&["spec", "cmd_positional_with_choices", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_with_choices_exec() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_positional_with_choices", "a"]);
+    snapshot_spec!(&["spec", "cmd_positional_with_choices", "a"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_with_choices_exec_fail() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_positional_with_choices", "x"]);
+    snapshot_spec!(&["spec", "cmd_positional_with_choices", "x"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_with_choices_and_default() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_positional_with_choices_and_default", "-h"]
-    );
+    snapshot_spec!(&["spec", "cmd_positional_with_choices_and_default", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_with_choices_and_default_exec() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_positional_with_choices_and_default"]
-    );
+    snapshot_spec!(&["spec", "cmd_positional_with_choices_and_default"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_with_choices_and_required() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_positional_with_choices_and_required", "-h"]
-    );
+    snapshot_spec!(&["spec", "cmd_positional_with_choices_and_required", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_positional_with_choices_and_required_exec_fail() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_positional_with_choices_and_required"]
-    );
+    snapshot_spec!(&["spec", "cmd_positional_with_choices_and_required"]);
 }
 
 #[test]
 fn test_spec_cmd_alias() {
-    snapshot!(SPEC_SCRIPT, &["spec", "alias"]);
+    snapshot_spec!(&["spec", "alias"]);
 }
 
 #[test]
 fn test_spec_cmd_without_any_arg() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_without_any_arg"]);
+    snapshot_spec!(&["spec", "cmd_without_any_arg"]);
 }
 
 #[test]
 fn test_spec_cmd_without_any_arg2() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_without_any_arg", "--opt2", "foo", "bar"]
-    );
+    snapshot_spec!(&["spec", "cmd_without_any_arg", "--opt2", "foo", "bar"]);
 }
 
 #[test]
 fn test_spec_cmd_without_any_arg_exec() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_without_any_arg", "foo", "bar"]);
+    snapshot_spec!(&["spec", "cmd_without_any_arg", "foo", "bar"]);
 }
 
 #[test]
 fn test_spec_cmd_without_any_arg_exec_eval() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_without_any_arg", "foo", "bar"]);
+    snapshot_spec!(&["spec", "cmd_without_any_arg", "foo", "bar"]);
 }
 
 #[test]
 fn test_spec_cmd_with_hyphens() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &[
-            "spec",
-            "cmd_with_hyphens",
-            "foo",
-            "--hyphen-flag",
-            "--hyphen-option",
-            "bar"
-        ]
-    );
+    snapshot_spec!(&[
+        "spec",
+        "cmd_with_hyphens",
+        "foo",
+        "--hyphen-flag",
+        "--hyphen-option",
+        "bar"
+    ]);
 }
 
 #[test]
 fn test_spec_nested_command() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_nested_command",]);
+    snapshot_spec!(&["spec", "cmd_nested_command",]);
 }
 
 #[test]
 fn test_spec_nested_command_exec() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_nested_command", "foo", "--opt1", "abc"]
-    );
+    snapshot_spec!(&["spec", "cmd_nested_command", "foo", "--opt1", "abc"]);
 }
 
 #[test]
 fn test_spec_nested_command2() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_nested_command2",]);
+    snapshot_spec!(&["spec", "cmd_nested_command2",]);
 }
 
 #[test]
 fn test_spec_cmd_no_long_flags() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_no_long_flags", "-h"]);
+    snapshot_spec!(&["spec", "cmd_no_long_flags", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_no_long_options() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_no_long_options", "-h"]);
+    snapshot_spec!(&["spec", "cmd_no_long_options", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_option_notations_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_option_notations", "-h"]);
+    snapshot_spec!(&["spec", "cmd_option_notations", "-h"]);
 }
 
 #[test]
 fn test_spec_cmd_option_notations() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_option_notations", "--opt2"]);
+    snapshot_spec!(&["spec", "cmd_option_notations", "--opt2"]);
 }
 #[test]
 fn test_spec_cmd_option_notations1() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_option_notations", "--opt2", "foo"]
-    );
+    snapshot_spec!(&["spec", "cmd_option_notations", "--opt2", "foo"]);
 }
 
 #[test]
 fn test_spec_cmd_option_notations2() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_option_notations", "--opt2", "foo", "bar"]
-    );
+    snapshot_spec!(&["spec", "cmd_option_notations", "--opt2", "foo", "bar"]);
 }
 
 #[test]
 fn test_spec_cmd_notation_values() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_notation_values", "-h"]);
+    snapshot_spec!(&["spec", "cmd_notation_values", "-h"]);
 }
 
 #[test]
 fn test_spec_help_command() {
-    snapshot!(SPEC_SCRIPT, &["spec", "help"]);
+    snapshot_spec!(&["spec", "help"]);
 }
 
 #[test]
 fn test_spec_help_command2() {
-    snapshot!(SPEC_SCRIPT, &["spec", "help", "cmd_preferred"]);
+    snapshot_spec!(&["spec", "help", "cmd_preferred"]);
 }
 
 #[test]
 fn test_spec_help_command3() {
-    snapshot!(SPEC_SCRIPT, &["spec", "help", "cmd_prefered"]);
+    snapshot_spec!(&["spec", "help", "cmd_prefered"]);
 }
 
 #[test]
 fn test_spec_cmd_combine_shorts() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_combine_shorts", "-ac", "yes"]);
+    snapshot_spec!(&["spec", "cmd_combine_shorts", "-ac", "yes"]);
 }
 
 #[test]
 fn test_spec_cmd_single_dash_help() {
-    snapshot!(SPEC_SCRIPT, &["spec", "cmd_single_dash", "-help"]);
+    snapshot_spec!(&["spec", "cmd_single_dash", "-help"]);
 }
 
 #[test]
 fn test_spec_cmd_single_dash() {
-    snapshot!(
-        SPEC_SCRIPT,
-        &["spec", "cmd_single_dash", "-flag1", "-opt1", "abc"]
-    );
+    snapshot_spec!(&["spec", "cmd_single_dash", "-flag1", "-opt1", "abc"]);
+}
+
+#[test]
+fn test_spec_cmd_positional_with_choices_fn() {
+    snapshot_spec!(&["spec", "cmd_positional_with_choices_fn", "xyz"]);
 }


### PR DESCRIPTION
```
# @cmd  Positional with choices and value
# @arg   arg[`_fn_bars`]  A arg with choices fn
cmd_positional_with_choices_fn() {
    print_argc_vars
}

_fn_bars() {
    echo a1
    echo a2
    echo a3
}
```
```
spec cmd_positional_with_choices_fn xyz
```

```
error: invalid value 'xyz' for '[ARG]'
  [possible values: a1, a2, a3]

For more information, try '--help'.
```
