### PR TITLE
feat: support recursive nested subcommand

### DIFF
--- a/tests/snapshots/integration__export__export.snap
+++ b/tests/snapshots/integration__export__export.snap
@@ -1375,7 +1375,18 @@ expression: output
           ],
           "positionals": [],
           "aliases": [],
-          "subcommands": []
+          "subcommands": [
+            {
+              "describe": "Recursive nested subcommand",
+              "name": "bar",
+              "author": null,
+              "version": null,
+              "options": [],
+              "positionals": [],
+              "aliases": [],
+              "subcommands": []
+            }
+          ]
         }
       ]
     },

--- a/tests/snapshots/integration__spec_test__spec_nested_command3.snap
+++ b/tests/snapshots/integration__spec_test__spec_nested_command3.snap
@@ -1,0 +1,24 @@
+---
+source: tests/spec_test.rs
+expression: output
+---
+RUN
+spec cmd_nested_command2 foo
+
+OUTPUT
+cat >&2 <<-'EOF' 
+Subcommand of nested command2
+
+USAGE: spec cmd_nested_command2 foo [OPTIONS] <COMMAND>
+
+OPTIONS:
+      --opt1 <OPT1>
+      --opt2 <OPT2>
+  -h, --help
+
+COMMANDS:
+  bar  Recursive nested subcommand
+
+EOF
+exit 0
+

--- a/tests/spec.sh
+++ b/tests/spec.sh
@@ -209,6 +209,10 @@ cmd_nested_command2() {
     :;
 }
 
+cmd_nested_command2::main() {
+    print_argc_vars
+}
+
 # @cmd Subcommand of nested command2
 # @option --opt1
 # @option --opt2
@@ -216,7 +220,8 @@ cmd_nested_command2::foo() {
     print_argc_vars
 }
 
-cmd_nested_command2::main() {
+# @cmd Recursive nested subcommand
+cmd_nested_command2::foo::bar() {
     print_argc_vars
 }
 

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -215,6 +215,11 @@ fn test_spec_nested_command2() {
 }
 
 #[test]
+fn test_spec_nested_command3() {
+    snapshot_spec!(&["spec", "cmd_nested_command2", "foo"]);
+}
+
+#[test]
 fn test_spec_cmd_no_long_flags() {
     snapshot_spec!(&["spec", "cmd_no_long_flags", "-h"]);
 }


### PR DESCRIPTION
```
# @cmd Recursive nested subcommand
cmd_nested_command2::foo::bar() {
    print_argc_vars
}
```