### PR TITLE
feat: support multi-line doc

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -709,7 +709,7 @@ fn comp_subcommands_positional(cmd: &Command, values: &[Vec<&str>]) -> Vec<(Stri
 fn comp_subcomands(cmd: &Command) -> Vec<(String, String)> {
     let mut output = vec![];
     for subcmd in cmd.subcommands.iter() {
-        let describe = subcmd.describe.clone().unwrap_or_default();
+        let describe = subcmd.describe.clone();
         for v in subcmd.list_names() {
             output.push((v, describe.clone()))
         }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -3,10 +3,11 @@ macro_rules! snapshot {
     (
 		$path:expr,
         $source:expr,
-        $args:expr
+        $args:expr,
+		$width:expr
     ) => {
         let args: Vec<String> = $args.iter().map(|v| v.to_string()).collect();
-        let values = argc::eval($path, $source, &args, None).unwrap();
+        let values = argc::eval($path, $source, &args, $width).unwrap();
         let output = argc::ArgcValue::to_shell(values);
         let args = $args.join(" ");
         let output = format!(
@@ -26,7 +27,7 @@ OUTPUT
 macro_rules! snapshot_spec {
     ($args:expr) => {
         let (path, source) = $crate::fixtures::get_spec();
-        snapshot!(Some(path.as_str()), source.as_str(), $args);
+        snapshot!(Some(path.as_str()), source.as_str(), $args, None);
     };
 }
 

--- a/tests/main_fn_test.rs
+++ b/tests/main_fn_test.rs
@@ -33,7 +33,7 @@ main() {
 }
     "###;
     plain!(script, &["prog", "cmd"], "cmd");
-    snapshot!(None, script, &["prog", "-h"]);
+    snapshot!(None, script, &["prog", "-h"], None);
 }
 
 #[test]
@@ -48,7 +48,7 @@ cmd() {
 
     "###;
     plain!(script, &["prog", "cmd"], "cmd");
-    snapshot!(None, script, &["prog"]);
+    snapshot!(None, script, &["prog"], None);
 }
 
 #[test]
@@ -62,5 +62,5 @@ cmd() {
 }
 
     "###;
-    snapshot!(None, script, &["prog", "-h"]);
+    snapshot!(None, script, &["prog", "-h"], None);
 }

--- a/tests/snapshots/integration__wrap_test__wrap.snap
+++ b/tests/snapshots/integration__wrap_test__wrap.snap
@@ -19,6 +19,7 @@ ARGS:
   [TARGET]  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed
             viverra tellus in hac habitasse platea.
+            Use '-' for standard input.
 
 OPTIONS:
       --foo <FOO>  Lorem ipsum dolor sit amet, consectetur adipiscing elit,

--- a/tests/snapshots/integration__wrap_test__wrap.snap
+++ b/tests/snapshots/integration__wrap_test__wrap.snap
@@ -2,8 +2,18 @@
 source: tests/wrap_test.rs
 expression: output
 ---
+RUN
+prog -h
+
+OUTPUT
 cat >&2 <<-'EOF' 
-USAGE: prog --help [OPTIONS] [TARGET] <COMMAND>
+A simple cli
+
+Extra lines after the @cmd or @describe, which don't start with an @, are 
+treated as the long description. A line which is not a comment ends
+the block.
+
+USAGE: prog [OPTIONS] [TARGET] <COMMAND>
 
 ARGS:
   [TARGET]  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -14,6 +24,9 @@ OPTIONS:
       --foo <FOO>  Lorem ipsum dolor sit amet, consectetur adipiscing elit,
                    sed do eiusmod tempor incididunt ut labore et dolore magna
                    aliqua. Neque laoreet suspendisse libero id.
+                    * default: enables recommended style components (default).
+                    * full: enables all available components.
+                    * auto: same as 'default', unless the output is piped.
   -h, --help       Print help
 
 COMMANDS:
@@ -23,3 +36,4 @@ COMMANDS:
 
 EOF
 exit 0
+

--- a/tests/snapshots/integration__wrap_test__wrap2.snap
+++ b/tests/snapshots/integration__wrap_test__wrap2.snap
@@ -1,0 +1,20 @@
+---
+source: tests/wrap_test.rs
+expression: output
+---
+RUN
+prog foo -h
+
+OUTPUT
+cat >&2 <<-'EOF' 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu cursus euismod quis viverra.
+
+Extra lines after the @cmd or @describe, which don't start with an @, are 
+treated as the long description. A line which is not a comment ends
+the block.
+
+USAGE: prog foo
+
+EOF
+exit 0
+

--- a/tests/wrap_test.rs
+++ b/tests/wrap_test.rs
@@ -10,6 +10,7 @@ const SCRIPT: &str = r###"
 #  * full: enables all available components.
 #  * auto: same as 'default', unless the output is piped.
 # @arg target Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed viverra tellus in hac habitasse platea.
+# Use '-' for standard input.
 # @cmd Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu cursus euismod quis viverra. 
 #
 # Extra lines after the @cmd or @describe, which don't start with an @, are 

--- a/tests/wrap_test.rs
+++ b/tests/wrap_test.rs
@@ -1,20 +1,30 @@
-macro_rules! snapshort_wrap {
-    ($source:expr, $width:expr) => {
-        let args: Vec<String> = vec!["prog --help".into()];
-        let values = argc::eval(None, $source, &args, Some($width)).unwrap();
-        let output = argc::ArgcValue::to_shell(values);
-        insta::assert_snapshot!(output);
-    };
-}
+const SCRIPT: &str = r###"
+# @describe A simple cli
+#
+# Extra lines after the @cmd or @describe, which don't start with an @, are 
+# treated as the long description. A line which is not a comment ends
+# the block.
 
-#[test]
-fn test_wrap() {
-    let script: &str = r###"
 # @option --foo Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Neque laoreet suspendisse libero id. 
+#  * default: enables recommended style components (default).
+#  * full: enables all available components.
+#  * auto: same as 'default', unless the output is piped.
 # @arg target Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed viverra tellus in hac habitasse platea.
 # @cmd Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu cursus euismod quis viverra. 
+#
+# Extra lines after the @cmd or @describe, which don't start with an @, are 
+# treated as the long description. A line which is not a comment ends
+# the block.
 foo() {
 }
 "###;
-    snapshort_wrap!(script, 80);
+
+#[test]
+fn test_wrap() {
+    snapshot!(None, SCRIPT, &["prog", "-h"], Some(80));
+}
+
+#[test]
+fn test_wrap2() {
+    snapshot!(None, SCRIPT, &["prog", "foo", "-h"], Some(80));
 }


### PR DESCRIPTION
close #97

```
# @describe A simple cli
#
# Extra lines after the @cmd or @describe, which don't start with an @, are 
# treated as the long description. A line which is not a comment ends
# the block.

# @option --foo Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Neque laoreet suspendisse libero id. 
#  * default: enables recommended style components (default).
#  * full: enables all available components.
#  * auto: same as 'default', unless the output is piped.
# @arg target Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed viverra tellus in hac habitasse platea.
# Use '-' for standard input.
# @cmd Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu cursus euismod quis viverra. 
#
# Extra lines after the @cmd or @describe, which don't start with an @, are 
# treated as the long description. A line which is not a comment ends
# the block.
foo() {
  :;
}

eval "$(TERM_WIDTH=`tput cols` argc --argc-eval "$0" "$@")"
```

run `prog -h`
```
A simple cli

Extra lines after the @cmd or @describe, which don't start with an @, are 
treated as the long description. A line which is not a comment ends
the block.

USAGE: prog [OPTIONS] [TARGET] <COMMAND>

ARGS:
  [TARGET]  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
            eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed
            viverra tellus in hac habitasse platea.
            Use '-' for standard input.
OPTIONS:
      --foo <FOO>  Lorem ipsum dolor sit amet, consectetur adipiscing elit,
                   sed do eiusmod tempor incididunt ut labore et dolore magna
                   aliqua. Neque laoreet suspendisse libero id.
                    * default: enables recommended style components (default).
                    * full: enables all available components.
                    * auto: same as 'default', unless the output is piped.
  -h, --help       Print help

COMMANDS:
  foo  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Arcu cursus euismod
       quis viverra.
```

run `prog foo -h`
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu cursus euismod quis viverra.

Extra lines after the @cmd or @describe, which don't start with an @, are 
treated as the long description. A line which is not a comment ends
the block.

USAGE: prog foo

```