### PR TITLE
feat: support skipping choice validate

### DIFF
--- a/src/command/root_data.rs
+++ b/src/command/root_data.rs
@@ -18,12 +18,12 @@ impl RootData {
         &mut self,
         position: usize,
         default_fn: &Option<String>,
-        choices_fn: &Option<String>,
+        choices_fn: &Option<(String, bool)>,
     ) {
         if let Some(default_fn) = default_fn.as_ref() {
             self.default_fns.push((default_fn.to_string(), position));
         }
-        if let Some(choices_fn) = choices_fn.as_ref() {
+        if let Some((choices_fn, _)) = choices_fn.as_ref() {
             self.choices_fns.push((choices_fn.to_string(), position));
         }
     }

--- a/src/param.rs
+++ b/src/param.rs
@@ -12,7 +12,7 @@ use std::fmt::Write;
 pub struct ParamData {
     pub(crate) name: String,
     pub(crate) choices: Option<Vec<String>>,
-    pub(crate) choices_fn: Option<String>,
+    pub(crate) choices_fn: Option<(String, bool)>,
     pub(crate) multiple: bool,
     pub(crate) required: bool,
     pub(crate) default: Option<String>,
@@ -41,7 +41,7 @@ pub struct FlagOptionParam {
     pub(crate) flag: bool,
     pub(crate) dashes: String,
     pub(crate) choices: Option<Vec<String>>,
-    pub(crate) choices_fn: Option<String>,
+    pub(crate) choices_fn: Option<(String, bool)>,
     pub(crate) multiple: bool,
     pub(crate) required: bool,
     pub(crate) default: Option<String>,
@@ -281,7 +281,7 @@ pub struct PositionalParam {
     pub(crate) name: String,
     pub(crate) describe: String,
     pub(crate) choices: Option<Vec<String>>,
-    pub(crate) choices_fn: Option<String>,
+    pub(crate) choices_fn: Option<(String, bool)>,
     pub(crate) multiple: bool,
     pub(crate) required: bool,
     pub(crate) default: Option<String>,
@@ -373,7 +373,7 @@ impl PositionalParam {
 fn render_name(
     name: &str,
     choices: &Option<Vec<String>>,
-    choices_fn: &Option<String>,
+    choices_fn: &Option<(String, bool)>,
     multiple: bool,
     required: bool,
     default: &Option<String>,
@@ -400,11 +400,12 @@ fn render_name(
             .collect();
         let choices_value = format!("[{}{}]", prefix, values.join("|"));
         name.push_str(&choices_value);
-    } else if let Some(choices_fn) = choices_fn {
+    } else if let Some((choices_fn, validate)) = choices_fn {
         if let Some(ch) = get_modifer(required, multiple) {
             name.push(ch)
         }
-        let _ = write!(name, "[`{}`]", choices_fn);
+        let validate_sign = if *validate { "" } else { "?" };
+        let _ = write!(name, "[{}`{}`]", validate_sign, choices_fn);
     } else if let Some(default) = default {
         let value = if default.chars().any(is_default_value_terminate) {
             format!("\"{}\"", default)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -400,10 +400,10 @@ fn parse_param_modifer_choices_fn(input: &str) -> nom::IResult<&str, ParamData> 
     map(
         pair(
             parse_param_modifer,
-            delimited(char('['), parse_value_fn, char(']')),
+            delimited(char('['), pair(opt(char('?')), parse_value_fn), char(']')),
         ),
-        |(mut arg, choices_fn)| {
-            arg.choices_fn = Some(choices_fn.into());
+        |(mut arg, (validate, choices_fn))| {
+            arg.choices_fn = Some((choices_fn.into(), validate.is_none()));
             arg
         },
     )(input)

--- a/tests/snapshots/integration__compgen__compgen.snap
+++ b/tests/snapshots/integration__compgen__compgen.snap
@@ -24,6 +24,7 @@ cmd_positional_with_default	Positional with default value
 cmd_positional_with_default_fn	Positional with default value
 cmd_positional_with_choices_and_default	Positional with choices and value
 cmd_positional_with_choices_fn	Positional with choices and value
+cmd_positional_with_choices_fn2	Positional with choices and value
 cmd_positional_with_choices_and_required	Positional with choices and required
 cmd_positional_with_choices_fn_and_required	Positional with choices and value
 cmd_without_any_arg	Command without any arg

--- a/tests/snapshots/integration__compgen__compgen_help.snap
+++ b/tests/snapshots/integration__compgen__compgen_help.snap
@@ -24,6 +24,7 @@ cmd_positional_with_default	Positional with default value
 cmd_positional_with_default_fn	Positional with default value
 cmd_positional_with_choices_and_default	Positional with choices and value
 cmd_positional_with_choices_fn	Positional with choices and value
+cmd_positional_with_choices_fn2	Positional with choices and value
 cmd_positional_with_choices_and_required	Positional with choices and required
 cmd_positional_with_choices_fn_and_required	Positional with choices and value
 cmd_without_any_arg	Command without any arg

--- a/tests/snapshots/integration__compgen__compgen_help2.snap
+++ b/tests/snapshots/integration__compgen__compgen_help2.snap
@@ -24,6 +24,7 @@ cmd_positional_with_default	Positional with default value
 cmd_positional_with_default_fn	Positional with default value
 cmd_positional_with_choices_and_default	Positional with choices and value
 cmd_positional_with_choices_fn	Positional with choices and value
+cmd_positional_with_choices_fn2	Positional with choices and value
 cmd_positional_with_choices_and_required	Positional with choices and required
 cmd_positional_with_choices_fn_and_required	Positional with choices and value
 cmd_without_any_arg	Command without any arg

--- a/tests/snapshots/integration__export__export.snap
+++ b/tests/snapshots/integration__export__export.snap
@@ -370,7 +370,10 @@ expression: output
           "flag": false,
           "dashes": "--",
           "choices": null,
-          "choices_fn": "_fn_bars",
+          "choices_fn": [
+            "_fn_bars",
+            true
+          ],
           "multiple": false,
           "required": false,
           "default": null,
@@ -384,7 +387,10 @@ expression: output
           "flag": false,
           "dashes": "--",
           "choices": null,
-          "choices_fn": "_fn_bars",
+          "choices_fn": [
+            "_fn_bars",
+            true
+          ],
           "multiple": false,
           "required": true,
           "default": null,
@@ -533,7 +539,10 @@ expression: output
           "flag": false,
           "dashes": "",
           "choices": null,
-          "choices_fn": "_fn_foo",
+          "choices_fn": [
+            "_fn_foo",
+            true
+          ],
           "multiple": false,
           "required": false,
           "default": null,
@@ -547,7 +556,10 @@ expression: output
           "flag": false,
           "dashes": "",
           "choices": null,
-          "choices_fn": "_fn_bars",
+          "choices_fn": [
+            "_fn_bars",
+            true
+          ],
           "multiple": false,
           "required": false,
           "default": null,
@@ -561,7 +573,10 @@ expression: output
           "flag": false,
           "dashes": "",
           "choices": null,
-          "choices_fn": "_fn_bars",
+          "choices_fn": [
+            "_fn_bars",
+            true
+          ],
           "multiple": false,
           "required": true,
           "default": null,
@@ -1115,7 +1130,35 @@ expression: output
           "name": "arg",
           "describe": "A arg with choices fn",
           "choices": null,
-          "choices_fn": "_fn_bars",
+          "choices_fn": [
+            "_fn_bars",
+            true
+          ],
+          "multiple": false,
+          "required": false,
+          "default": null,
+          "default_fn": null,
+          "value_name": null
+        }
+      ],
+      "aliases": [],
+      "subcommands": []
+    },
+    {
+      "describe": "Positional with choices and value",
+      "name": "cmd_positional_with_choices_fn2",
+      "author": null,
+      "version": null,
+      "options": [],
+      "positionals": [
+        {
+          "name": "arg",
+          "describe": "A arg with choices fn, skip validate choice",
+          "choices": null,
+          "choices_fn": [
+            "_fn_bars",
+            false
+          ],
           "multiple": false,
           "required": false,
           "default": null,
@@ -1162,7 +1205,10 @@ expression: output
           "name": "arg",
           "describe": "A arg with choices fn and required",
           "choices": null,
-          "choices_fn": "_fn_bars",
+          "choices_fn": [
+            "_fn_bars",
+            true
+          ],
           "multiple": false,
           "required": true,
           "default": null,
@@ -1492,7 +1538,10 @@ expression: output
           "name": "args",
           "describe": "",
           "choices": null,
-          "choices_fn": "_fn_args",
+          "choices_fn": [
+            "_fn_args",
+            true
+          ],
           "multiple": true,
           "required": false,
           "default": null,

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_fn2.snap
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_fn2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/spec_test.rs
-assertion_line: 294
 expression: output
 ---
 RUN

--- a/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_fn2.snap.new
+++ b/tests/snapshots/integration__spec_test__spec_cmd_positional_with_choices_fn2.snap.new
@@ -1,0 +1,12 @@
+---
+source: tests/spec_test.rs
+assertion_line: 294
+expression: output
+---
+RUN
+spec cmd_positional_with_choices_fn2 xyz
+
+OUTPUT
+argc_arg=xyz
+cmd_positional_with_choices_fn2 xyz
+

--- a/tests/snapshots/integration__spec_test__spec_help.snap
+++ b/tests/snapshots/integration__spec_test__spec_help.snap
@@ -32,6 +32,7 @@ COMMANDS:
   cmd_positional_with_default_fn               Positional with default value
   cmd_positional_with_choices_and_default      Positional with choices and value
   cmd_positional_with_choices_fn               Positional with choices and value
+  cmd_positional_with_choices_fn2              Positional with choices and value
   cmd_positional_with_choices_and_required     Positional with choices and required
   cmd_positional_with_choices_fn_and_required  Positional with choices and value
   cmd_without_any_arg                          Command without any arg

--- a/tests/snapshots/integration__spec_test__spec_help_command.snap
+++ b/tests/snapshots/integration__spec_test__spec_help_command.snap
@@ -32,6 +32,7 @@ COMMANDS:
   cmd_positional_with_default_fn               Positional with default value
   cmd_positional_with_choices_and_default      Positional with choices and value
   cmd_positional_with_choices_fn               Positional with choices and value
+  cmd_positional_with_choices_fn2              Positional with choices and value
   cmd_positional_with_choices_and_required     Positional with choices and required
   cmd_positional_with_choices_fn_and_required  Positional with choices and value
   cmd_without_any_arg                          Command without any arg

--- a/tests/snapshots/integration__spec_test__spec_help_command3.snap
+++ b/tests/snapshots/integration__spec_test__spec_help_command3.snap
@@ -8,7 +8,7 @@ spec help cmd_prefered
 OUTPUT
 cat >&2 <<-'EOF' 
 error: invalid value 'cmd_prefered' for '<command>'
-  [possible values: cmd_preferred, cmd_omitted, cmd_flag_names, cmd_no_long_flags, cmd_option_names, cmd_no_long_options, cmd_option_formats, cmd_option_quotes, cmd_option_notations, cmd_flag_formats, cmd_positional_only, cmd_positional_many, cmd_positional_requires, cmd_positional_with_choices, cmd_positional_with_default, cmd_positional_with_default_fn, cmd_positional_with_choices_and_default, cmd_positional_with_choices_fn, cmd_positional_with_choices_and_required, cmd_positional_with_choices_fn_and_required, cmd_without_any_arg, cmd_alias, a, alias, cmd_with_hyphens, cmd_nested_command, cmd_nested_command2, cmd_notation_values, cmd_dynamic_compgen, cmd_combine_shorts, cmd_single_dash, cmd_two_multiple_positionals]
+  [possible values: cmd_preferred, cmd_omitted, cmd_flag_names, cmd_no_long_flags, cmd_option_names, cmd_no_long_options, cmd_option_formats, cmd_option_quotes, cmd_option_notations, cmd_flag_formats, cmd_positional_only, cmd_positional_many, cmd_positional_requires, cmd_positional_with_choices, cmd_positional_with_default, cmd_positional_with_default_fn, cmd_positional_with_choices_and_default, cmd_positional_with_choices_fn, cmd_positional_with_choices_fn2, cmd_positional_with_choices_and_required, cmd_positional_with_choices_fn_and_required, cmd_without_any_arg, cmd_alias, a, alias, cmd_with_hyphens, cmd_nested_command, cmd_nested_command2, cmd_notation_values, cmd_dynamic_compgen, cmd_combine_shorts, cmd_single_dash, cmd_two_multiple_positionals]
 
 For more information, try '--help'.
 

--- a/tests/spec.sh
+++ b/tests/spec.sh
@@ -156,6 +156,12 @@ cmd_positional_with_choices_fn() {
     print_argc_vars
 }
 
+# @cmd  Positional with choices and value
+# @arg   arg[?`_fn_bars`]  A arg with choices fn, skip validate choice
+cmd_positional_with_choices_fn2() {
+    print_argc_vars
+}
+
 # @cmd  Positional with choices and required
 # @arg   arg![a|b]   A arg with choices and required
 cmd_positional_with_choices_and_required() {

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -290,6 +290,11 @@ fn test_spec_cmd_positional_with_choices_fn() {
 }
 
 #[test]
+fn test_spec_cmd_positional_with_choices_fn2() {
+    snapshot_spec!(&["spec", "cmd_positional_with_choices_fn2", "xyz"]);
+}
+
+#[test]
 fn test_spec_cmd_two_multiple_positionals() {
     snapshot_spec!(&["spec", "cmd_two_multiple_positionals", "abc", "def", "cjk"]);
 }


### PR DESCRIPTION
Prepend `?` to choices_fn to skip validate choice value
```
# @option --foo1[`_fn_foo`]
# @option --foo2[?`_fn_foo`]

_fn_foo() {
    echo a1
    echo a2
}
```
Run `test.sh --foo1 aa`
```
error: invalid value 'aa' for '<FOO1>'
  [possible values: a1, a2]

For more information, try '--help'.
```

Run `test.sh --foo2 aa`
```
argc_foo2=aa
```