### PR TITLE
refactor: adjust signature of eval fn

### DIFF
--- a/src/bin/argc/main.rs
+++ b/src/bin/argc/main.rs
@@ -42,7 +42,7 @@ fn run() -> Result<i32> {
         match argc_cmd {
             "--argc-eval" => {
                 let (source, cmd_args) = parse_script_args(&args[2..])?;
-                let values = argc::eval(Some(&args[2]), &source, &cmd_args, termwidth())?;
+                let values = argc::eval(&source, &cmd_args, Some(&args[2]), termwidth())?;
                 println!("{}", argc::ArgcValue::to_shell(values))
             }
             "--argc-create" => {

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -18,13 +18,13 @@ use std::result::Result as StdResult;
 use std::sync::Arc;
 
 pub fn eval(
-    script_path: Option<&str>,
     script_content: &str,
     args: &[String],
+    script_path: Option<&str>,
     term_width: Option<usize>,
 ) -> Result<Vec<ArgcValue>> {
     let mut cmd = Command::new(script_content)?;
-    cmd.eval(script_path, args, term_width)
+    cmd.eval(args, script_path, term_width)
 }
 
 pub fn export(source: &str) -> Result<serde_json::Value> {
@@ -58,8 +58,8 @@ impl Command {
 
     pub fn eval(
         &mut self,
-        script_path: Option<&str>,
         args: &[String],
+        script_path: Option<&str>,
         term_width: Option<usize>,
     ) -> Result<Vec<ArgcValue>> {
         if args.is_empty() {

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -20,7 +20,7 @@ macro_rules! fail {
         $err:expr
     ) => {
         let args: Vec<String> = $args.iter().map(|v| v.to_string()).collect();
-        let err = argc::eval(None, $source, &args, None).unwrap_err();
+        let err = argc::eval($source, &args, None, None).unwrap_err();
         assert_eq!(err.to_string().as_str(), $err);
     };
 }
@@ -30,17 +30,17 @@ macro_rules! snapshot {
     ($source:expr, $args:expr) => {
         let (script_path, script_content, script_file) =
             $crate::fixtures::create_argc_script($source, "script.sh");
-        snapshot!(Some(script_path.as_str()), &script_content, $args, None);
+        snapshot!(&script_content, $args, Some(script_path.as_str()), None);
         script_file.close().unwrap();
     };
     (
-		$path:expr,
         $source:expr,
         $args:expr,
+		$path:expr,
 		$width:expr
     ) => {
         let args: Vec<String> = $args.iter().map(|v| v.to_string()).collect();
-        let values = argc::eval($path, $source, &args, $width).unwrap();
+        let values = argc::eval($source, &args, $path, $width).unwrap();
         let shell_code = argc::ArgcValue::to_shell(values);
         let args = $args.join(" ");
         let data = format!(
@@ -68,7 +68,7 @@ macro_rules! snapshot_multi {
         for args in $matrix.iter() {
             let args: Vec<String> = args.iter().map(|v| v.to_string()).collect();
             let values =
-                argc::eval(Some(script_path.as_str()), &script_content, &args, None).unwrap();
+                argc::eval(&script_content, &args, Some(script_path.as_str()), None).unwrap();
             let args = args.join(" ");
             let piece = format!(
                 r###"************ RUN ************

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -66,7 +66,7 @@ fn arg_choice_fn() {
 
 #[test]
 fn arg_choice_fn_pass() {
-    snapshot!(None, SCRIPT_ARGS, &["prog", "cmdj", "val"], None);
+    snapshot!(SCRIPT_ARGS, &["prog", "cmdj", "val"], None, None);
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn option_choice_fn() {
 
 #[test]
 fn option_choice_fn_pass() {
-    snapshot!(None, SCRIPT_OPTIONS, &["prog", "cmda", "--cc", "val"], None);
+    snapshot!(SCRIPT_OPTIONS, &["prog", "cmda", "--cc", "val"], None, None);
 }
 
 #[test]

--- a/tests/wrap_help.rs
+++ b/tests/wrap_help.rs
@@ -21,15 +21,15 @@ foo() { :; }
 
 #[test]
 fn wrap() {
-    snapshot!(None, SCRIPT, &["prog", "-h"], Some(80));
+    snapshot!(SCRIPT, &["prog", "-h"], None, Some(80));
 }
 
 #[test]
 fn wrap2() {
-    snapshot!(None, SCRIPT, &["prog", "foo", "-h"], Some(80));
+    snapshot!(SCRIPT, &["prog", "foo", "-h"], None, Some(80));
 }
 
 #[test]
 fn nowrap() {
-    snapshot!(None, SCRIPT, &["prog", "-h"], None);
+    snapshot!(SCRIPT, &["prog", "-h"], None, None);
 }


### PR DESCRIPTION
```
pub fn eval(
    script_path: Option<&str>,
    script_content: &str,
    args: &[String],
    term_width: Option<usize>,
)
```
change to
```
pub fn eval(
    script_content: &str,
    args: &[String],
    script_path: Option<&str>,
    term_width: Option<usize>,
)
```