### PR TITLE
feat: complete files on value name contains arg/any

### DIFF
--- a/src/compgen.rs
+++ b/src/compgen.rs
@@ -198,6 +198,8 @@ fn expand_candicates(
                 output[0] = ("__argc_comp:file".into(), String::new());
             } else if value_name.contains("dir") || value_name.contains("folder") {
                 output[0] = ("__argc_comp:dir".into(), String::new());
+            } else if value_name.contains("arg") || value_name.contains("any") {
+                output[0] = ("__argc_comp:file".into(), String::new());
             } else {
                 output.clear();
             };

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -188,3 +188,26 @@ cmdb() { :; }
 "###;
     snapshot_compgen!(script, vec![" ", "cmda ",]);
 }
+
+#[test]
+fn no_param() {
+    let script = r###"
+# @cmd
+cmd() { :; }
+"###;
+    snapshot_compgen!(script, vec!["cmd ",]);
+}
+
+#[test]
+fn special_arg_name() {
+    let script = r###"
+# @cmd
+# @arg arg
+cmda() { :; }
+
+# @cmd
+# @arg any
+cmdb() { :; }
+"###;
+    snapshot_compgen!(script, vec!["cmda ", "cmdb "]);
+}

--- a/tests/snapshots/integration__compgen__no_param.snap
+++ b/tests/snapshots/integration__compgen__no_param.snap
@@ -1,0 +1,8 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog cmd ` ************
+__argc_comp:file
+
+

--- a/tests/snapshots/integration__compgen__special_arg_name.snap
+++ b/tests/snapshots/integration__compgen__special_arg_name.snap
@@ -1,0 +1,11 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog cmda ` ************
+__argc_comp:file
+
+************ COMPGEN `prog cmdb ` ************
+__argc_comp:file
+
+


### PR DESCRIPTION
```sh
# @cmd
# @arg arg
cmda() { :; }

# @cmd
# @arg any
cmdb() { :; }
```

run `argc --argc-compgen fish test.sh 'cmda '`
```
__argc_comp:file
```
run `argc --argc-compgen fish test.sh 'cmdb '`
```
__argc_comp:file
```