### PR TITLE
fix: compgen only one combine shorts

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -221,17 +221,23 @@ impl<'a, 'b> Matcher<'a, 'b> {
     pub fn compgen(&self) -> Vec<(String, String)> {
         match &self.arg_comp {
             ArgComp::FlagOrOption => self.comp_flag_options(),
-            ArgComp::FlagOrOptionCombine(value) => self
-                .comp_flag_options()
-                .iter()
-                .filter_map(|(x, y)| {
-                    if x.len() == 2 {
-                        Some((format!("{value}{}", &x[1..]), y.to_string()))
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
+            ArgComp::FlagOrOptionCombine(value) => {
+                let mut output: Vec<(String, String)> = self
+                    .comp_flag_options()
+                    .iter()
+                    .filter_map(|(x, y)| {
+                        if x.len() == 2 {
+                            Some((format!("{value}{}", &x[1..]), y.to_string()))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                if output.len() == 1 {
+                    output.insert(0, (value.to_string(), String::new()));
+                }
+                output
+            }
             ArgComp::CommandOrPositional => {
                 let level = self.cmds.len() - 1;
                 let mut cmd = self.cmds[level].1;

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -211,3 +211,12 @@ cmdb() { :; }
 "###;
     snapshot_compgen!(script, vec!["cmda ", "cmdb "]);
 }
+
+#[test]
+fn one_combine_shorts() {
+    let script = r###"
+# @flag -a
+# @flag -b
+"###;
+    snapshot_compgen!(script, vec![" -a"]);
+}

--- a/tests/snapshots/integration__compgen__one_combine_shorts.snap
+++ b/tests/snapshots/integration__compgen__one_combine_shorts.snap
@@ -1,0 +1,9 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog  -a` ************
+-a
+-ab
+
+


### PR DESCRIPTION
```
# @flag -a
# @flag -b
```
When we press `prog -a<tab>`, `-ab` will be committed automatically.
This pr adds current word to candicates to avoid such autocommits.