### PR TITLE
refactor: --argc-compgen line parameter no skip first word

### DIFF
--- a/src/bin/argc/completions/argc.bash
+++ b/src/bin/argc/completions/argc.bash
@@ -11,7 +11,7 @@ _argc_completer() {
         _argc_complete_path "$cur"
         return
     fi
-    local line="${COMP_WORDS[@]:1:COMP_CWORD}"
+    local line="${COMP_WORDS[@]:0:COMP_CWORD}"
 
     local IFS=$'\n'
     export COMP_WORDBREAKS

--- a/src/bin/argc/completions/argc.elv
+++ b/src/bin/argc/completions/argc.elv
@@ -26,10 +26,7 @@ fn argc-completer {|@words|
         argc-complete-path $words[-1]
         return
     }
-    var line = (all $words[1..] | str:join ' ')
-    if (eq $line '') {
-        set line = ' '
-    }
+    var line = (all $words | str:join ' ')
     var candicates = [(argc --argc-compgen elvish $scriptfile $line)]
     if (eq (count $candicates) (num 1)) {
         if (eq $candicates[0] '__argc_comp:file') {

--- a/src/bin/argc/completions/argc.fish
+++ b/src/bin/argc/completions/argc.fish
@@ -11,7 +11,7 @@ function _argc_completer
         __fish_complete_path
         return
     end
-    set -l line "$words[2..]"
+    set -l line "$words"
     set -l candicates (argc --argc-compgen fish $scriptfile $line 2>/dev/null)
     if test (count $candicates) -eq 1
         if [ "$candicates[1]" = "__argc_comp:file" ]

--- a/src/bin/argc/completions/argc.nu
+++ b/src/bin/argc/completions/argc.nu
@@ -35,10 +35,7 @@ def _argc_completer [words: list<string>] {
     if not ($scriptfile | path exists) {
         return (_argc_complete_path ($words | last) false | _argc_complete_list)
     }
-    mut line = ($words | skip 1 | str join " ")
-    if $line == "" {
-        $line = " "
-    }
+    let line = ($words | str join " ")
     mut candicates = ((argc --argc-compgen fish $scriptfile $line) | str trim | split row "\n")
     if ($candicates | length) == 1  {
         if $candicates.0 == '__argc_comp:file' {

--- a/src/bin/argc/completions/argc.ps1
+++ b/src/bin/argc/completions/argc.ps1
@@ -16,10 +16,7 @@ $_argc_completer = {
     if (-not(Test-Path -Path $scriptfile -PathType Leaf)) {
         return
     }
-    $line = $words[1..($words.Count-1)] -join " "
-    if ($line -eq "") {
-        $line = " "
-    }
+    $line = $words[0..($words.Count-1)] -join " "
     $candicates = @((argc --argc-compgen powershell $scriptfile $line 2>$null).Split("`n"))
     if ($candicates.Count -eq 1) {
         if (($candicates[0] -eq "__argc_comp:file") -or ($candicates[0] -eq "__argc_comp:dir")) {

--- a/src/bin/argc/completions/argc.zsh
+++ b/src/bin/argc/completions/argc.zsh
@@ -11,7 +11,7 @@ _argc_completer()
         _path_files
         return
     fi
-    local line="${words[2,$CURRENT]}"
+    local line="${words[1,$CURRENT]}"
     local IFS=$'\n'
     local candicates=( $(argc --argc-compgen zsh "$scriptfile" "$line" 2>/dev/null) )
     if [[ ${#candicates[@]} -eq 1 ]]; then

--- a/src/bin/argc/main.rs
+++ b/src/bin/argc/main.rs
@@ -67,7 +67,7 @@ fn run() -> Result<i32> {
                 };
                 let (source, cmd_args) = parse_script_args(&args[3..])?;
                 let line = cmd_args.get(1).cloned().unwrap_or_default();
-                let output = argc::compgen(shell, &args[3], &source, &cmd_args[0], &line)?;
+                let output = argc::compgen(shell, &args[3], &source, &line)?;
                 println!("{output}");
             }
             "--argc-completions" => {

--- a/src/compgen.rs
+++ b/src/compgen.rs
@@ -9,7 +9,6 @@ pub fn compgen(
     shell: Shell,
     script_path: &str,
     script_content: &str,
-    bin_name: &str,
     line: &str,
 ) -> Result<String> {
     let (last_word, unbalance_char) = get_last_word(line);
@@ -19,9 +18,11 @@ pub fn compgen(
         line.to_string()
     };
     let mut args = split_shell_words(&line)?;
-    args.insert(0, bin_name.to_string());
     if last_word.is_empty() {
         args.push("".into());
+    }
+    if args.len() == 1 {
+        return Ok(String::new());
     }
     let cmd = Command::new(script_content)?;
     let matcher = Matcher::new(&cmd, &args);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -35,7 +35,7 @@ fn compgen() {
         .arg("--argc-compgen")
         .arg("bash")
         .arg(path)
-        .arg("cmdj ")
+        .arg("args cmdj ")
         .env("PATH", path_env_var)
         .assert()
         .stdout(predicates::str::contains("abc\ndef\nghi"))

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -12,25 +12,25 @@ fn multiple() {
     snapshot_compgen!(
         script,
         vec![
-            " ",
-            " --",
-            " -- ",
-            " -f ",
-            " --fc ",
-            " -o ",
-            " -o d1",
-            " -o d1 ",
-            " -o d1 d2",
-            " -o d1 d2 ",
-            " -d d1",
-            " -d d1 ",
-            " -d d1 d2",
-            " -d d1 d2 ",
-            " -d d1 d2 ",
-            " v1",
-            " v1 ",
-            " v1 v2",
-            " v1 v2 ",
+            "prog  ",
+            "prog --",
+            "prog -- ",
+            "prog -f ",
+            "prog --fc ",
+            "prog -o ",
+            "prog -o d1",
+            "prog -o d1 ",
+            "prog -o d1 d2",
+            "prog -o d1 d2 ",
+            "prog -d d1",
+            "prog -d d1 ",
+            "prog -d d1 d2",
+            "prog -d d1 d2 ",
+            "prog -d d1 d2 ",
+            "prog v1",
+            "prog v1 ",
+            "prog v1 v2",
+            "prog v1 v2 ",
         ]
     );
 }
@@ -49,8 +49,20 @@ fn shorts() {
     snapshot_compgen!(
         SCRIPT,
         vec![
-            " ", " -", " --", " -a", " -a ", " -af", " -af ", " -ae", " -ae ", " -abe", " -abe ",
-            " -s", " -sa", " -sa ",
+            "prog ",
+            "prog -",
+            "prog --",
+            "prog -a",
+            "prog -a ",
+            "prog -af",
+            "prog -af ",
+            "prog -ae",
+            "prog -ae ",
+            "prog -abe",
+            "prog -abe ",
+            "prog -s",
+            "prog -sa",
+            "prog -sa ",
         ]
     );
 }
@@ -68,13 +80,13 @@ cmdb() { :; }
     snapshot_compgen!(
         SCRIPT,
         vec![
-            " ",
-            " c",
-            " cmda",
-            " cmda ",
-            " help ",
-            " help c",
-            " help cmda ",
+            "prog ",
+            "prog c",
+            "prog cmda",
+            "prog cmda ",
+            "prog help ",
+            "prog help c",
+            "prog help cmda ",
         ]
     );
 }
@@ -94,13 +106,13 @@ cmd::subb() { :; }
     snapshot_compgen!(
         SCRIPT,
         vec![
-            " cmd",
-            " cmd ",
-            " cmd s",
-            " cmd suba",
-            " cmd suba ",
-            " cmd help  ",
-            " cmd help s",
+            "prog cmd",
+            "prog cmd ",
+            "prog cmd s",
+            "prog cmd suba",
+            "prog cmd suba ",
+            "prog cmd help  ",
+            "prog cmd help s",
         ]
     );
 }
@@ -128,23 +140,23 @@ cmdc() { :; }
     snapshot_compgen!(
         script,
         vec![
-            "cmda ",
-            "cmda v1",
-            "cmda v1 ",
-            "cmda v1 v2",
-            "cmda v1 v2 ",
-            "cmdb ",
-            "cmdb v1",
-            "cmdb v1 ",
-            "cmdb v1 v2",
-            "cmdb v1 v2 ",
-            "cmdb v1 v2 v3",
-            "cmdb v1 v2 v3 ",
-            "cmdc ",
-            "cmdc v1",
-            "cmdc v1 ",
-            "cmdc v1 v2",
-            "cmdc v1 v2 ",
+            "prog cmda ",
+            "prog cmda v1",
+            "prog cmda v1 ",
+            "prog cmda v1 v2",
+            "prog cmda v1 v2 ",
+            "prog cmdb ",
+            "prog cmdb v1",
+            "prog cmdb v1 ",
+            "prog cmdb v1 v2",
+            "prog cmdb v1 v2 ",
+            "prog cmdb v1 v2 v3",
+            "prog cmdb v1 v2 v3 ",
+            "prog cmdc ",
+            "prog cmdc v1",
+            "prog cmdc v1 ",
+            "prog cmdc v1 v2",
+            "prog cmdc v1 v2 ",
         ]
     );
 }
@@ -161,7 +173,16 @@ _choice_fn() {
 }
 "###;
 
-    snapshot_compgen!(script, vec![" --oa ", " --oa=", " --ob ", " ", " v1 ",]);
+    snapshot_compgen!(
+        script,
+        vec![
+            "prog --oa ",
+            "prog --oa=",
+            "prog --ob ",
+            "prog ",
+            "prog v1 ",
+        ]
+    );
 }
 
 #[test]
@@ -173,7 +194,7 @@ _choice_fn() {
 }
 "###;
 
-    snapshot_compgen!(script, vec![" --oa ", " --oa="]);
+    snapshot_compgen!(script, vec!["prog --oa ", "prog --oa="]);
 }
 
 #[test]
@@ -181,7 +202,10 @@ fn option_multi_vals() {
     let script = r###"
 # @option --oa* <DIR> <FILE>
 "###;
-    snapshot_compgen!(script, vec![" --oa ", " --oa bash ", " --oa bash cmd1 ",]);
+    snapshot_compgen!(
+        script,
+        vec!["prog --oa ", "prog --oa bash ", "prog --oa bash cmd1 ",]
+    );
 }
 
 #[test]
@@ -198,7 +222,7 @@ cmda() { :; }
 # @cmd line
 cmdb() { :; }
 "###;
-    snapshot_compgen!(script, vec![" ", "cmda ",]);
+    snapshot_compgen!(script, vec!["prog ", "prog cmda ",]);
 }
 
 #[test]
@@ -207,7 +231,7 @@ fn no_param() {
 # @cmd
 cmd() { :; }
 "###;
-    snapshot_compgen!(script, vec!["cmd ",]);
+    snapshot_compgen!(script, vec!["prog cmd ",]);
 }
 
 #[test]
@@ -221,7 +245,7 @@ cmda() { :; }
 # @arg any
 cmdb() { :; }
 "###;
-    snapshot_compgen!(script, vec!["cmda ", "cmdb "]);
+    snapshot_compgen!(script, vec!["prog cmda ", "prog cmdb "]);
 }
 
 #[test]
@@ -230,5 +254,5 @@ fn one_combine_shorts() {
 # @flag -a
 # @flag -b
 "###;
-    snapshot_compgen!(script, vec![" -a"]);
+    snapshot_compgen!(script, vec!["prog -a"]);
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -98,18 +98,13 @@ macro_rules! snapshot_compgen {
         let (script_path, script_content, script_file) =
             $crate::fixtures::create_argc_script($source, "compgen.sh");
         for line in $matrix.iter() {
-            let words = match argc::compgen(
-                argc::Shell::Fish,
-                &script_path,
-                &script_content,
-                "test",
-                line,
-            ) {
+            let words = match argc::compgen(argc::Shell::Fish, &script_path, &script_content, line)
+            {
                 Ok(stdout) => stdout,
                 Err(stderr) => stderr.to_string(),
             };
             let piece = format!(
-                r###"************ COMPGEN `prog {}` ************
+                r###"************ COMPGEN `{}` ************
 {}
 
 "###,

--- a/tests/snapshots/integration__compgen__choice.snap
+++ b/tests/snapshots/integration__compgen__choice.snap
@@ -2,29 +2,29 @@
 source: tests/compgen.rs
 expression: data
 ---
-************ COMPGEN `prog  --oa ` ************
+************ COMPGEN `prog --oa ` ************
 abc
 def
 ghi
 
-************ COMPGEN `prog  --oa=` ************
+************ COMPGEN `prog --oa=` ************
 --oa=abc
 --oa=def
 --oa=ghi
 
-************ COMPGEN `prog  --ob ` ************
+************ COMPGEN `prog --ob ` ************
 x
 y
 z
 
-************ COMPGEN `prog  ` ************
+************ COMPGEN `prog ` ************
 --oa
 --ob
 x
 y
 z
 
-************ COMPGEN `prog  v1 ` ************
+************ COMPGEN `prog v1 ` ************
 --oa
 --ob
 abc

--- a/tests/snapshots/integration__compgen__choice_multi.snap
+++ b/tests/snapshots/integration__compgen__choice_multi.snap
@@ -2,12 +2,12 @@
 source: tests/compgen.rs
 expression: data
 ---
-************ COMPGEN `prog  --oa ` ************
+************ COMPGEN `prog --oa ` ************
 abc
 def
 ghi
 
-************ COMPGEN `prog  --oa=` ************
+************ COMPGEN `prog --oa=` ************
 --oa=abc
 --oa=def
 --oa=ghi

--- a/tests/snapshots/integration__compgen__multiline_doc.snap
+++ b/tests/snapshots/integration__compgen__multiline_doc.snap
@@ -2,7 +2,7 @@
 source: tests/compgen.rs
 expression: data
 ---
-************ COMPGEN `prog  ` ************
+************ COMPGEN `prog ` ************
 cmda	cmd-line1
 cmdb	line
 

--- a/tests/snapshots/integration__compgen__multiple.snap
+++ b/tests/snapshots/integration__compgen__multiple.snap
@@ -11,24 +11,15 @@ expression: data
 -d
 [FILE]...
 
-************ COMPGEN `prog  --` ************
+************ COMPGEN `prog --` ************
 --fc
 --oa
 --od
 
-************ COMPGEN `prog  -- ` ************
+************ COMPGEN `prog -- ` ************
 __argc_comp:file
 
-************ COMPGEN `prog  -f ` ************
---fc
--f
---oa
--o
---od
--d
-[FILE]...
-
-************ COMPGEN `prog  --fc ` ************
+************ COMPGEN `prog -f ` ************
 --fc
 -f
 --oa
@@ -37,48 +28,7 @@ __argc_comp:file
 -d
 [FILE]...
 
-************ COMPGEN `prog  -o ` ************
-__argc_comp:dir
-
-************ COMPGEN `prog  -o d1` ************
-__argc_comp:dir
-
-************ COMPGEN `prog  -o d1 ` ************
-__argc_comp:dir
-
-************ COMPGEN `prog  -o d1 d2` ************
-__argc_comp:dir
-
-************ COMPGEN `prog  -o d1 d2 ` ************
-__argc_comp:dir
-
-************ COMPGEN `prog  -d d1` ************
-__argc_comp:dir
-
-************ COMPGEN `prog  -d d1 ` ************
-__argc_comp:file
-
-************ COMPGEN `prog  -d d1 d2` ************
-__argc_comp:file
-
-************ COMPGEN `prog  -d d1 d2 ` ************
---fc
--f
---oa
--o
-[FILE]...
-
-************ COMPGEN `prog  -d d1 d2 ` ************
---fc
--f
---oa
--o
-[FILE]...
-
-************ COMPGEN `prog  v1` ************
-__argc_comp:file
-
-************ COMPGEN `prog  v1 ` ************
+************ COMPGEN `prog --fc ` ************
 --fc
 -f
 --oa
@@ -87,10 +37,60 @@ __argc_comp:file
 -d
 [FILE]...
 
-************ COMPGEN `prog  v1 v2` ************
+************ COMPGEN `prog -o ` ************
+__argc_comp:dir
+
+************ COMPGEN `prog -o d1` ************
+__argc_comp:dir
+
+************ COMPGEN `prog -o d1 ` ************
+__argc_comp:dir
+
+************ COMPGEN `prog -o d1 d2` ************
+__argc_comp:dir
+
+************ COMPGEN `prog -o d1 d2 ` ************
+__argc_comp:dir
+
+************ COMPGEN `prog -d d1` ************
+__argc_comp:dir
+
+************ COMPGEN `prog -d d1 ` ************
 __argc_comp:file
 
-************ COMPGEN `prog  v1 v2 ` ************
+************ COMPGEN `prog -d d1 d2` ************
+__argc_comp:file
+
+************ COMPGEN `prog -d d1 d2 ` ************
+--fc
+-f
+--oa
+-o
+[FILE]...
+
+************ COMPGEN `prog -d d1 d2 ` ************
+--fc
+-f
+--oa
+-o
+[FILE]...
+
+************ COMPGEN `prog v1` ************
+__argc_comp:file
+
+************ COMPGEN `prog v1 ` ************
+--fc
+-f
+--oa
+-o
+--od
+-d
+[FILE]...
+
+************ COMPGEN `prog v1 v2` ************
+__argc_comp:file
+
+************ COMPGEN `prog v1 v2 ` ************
 --fc
 -f
 --oa

--- a/tests/snapshots/integration__compgen__nested_subcmds.snap
+++ b/tests/snapshots/integration__compgen__nested_subcmds.snap
@@ -2,28 +2,28 @@
 source: tests/compgen.rs
 expression: data
 ---
-************ COMPGEN `prog  cmd` ************
+************ COMPGEN `prog cmd` ************
 cmd
 
-************ COMPGEN `prog  cmd ` ************
+************ COMPGEN `prog cmd ` ************
 suba
 subb
 
-************ COMPGEN `prog  cmd s` ************
+************ COMPGEN `prog cmd s` ************
 suba
 subb
 
-************ COMPGEN `prog  cmd suba` ************
+************ COMPGEN `prog cmd suba` ************
 suba
 
-************ COMPGEN `prog  cmd suba ` ************
+************ COMPGEN `prog cmd suba ` ************
 __argc_comp:file
 
-************ COMPGEN `prog  cmd help  ` ************
+************ COMPGEN `prog cmd help  ` ************
 suba
 subb
 
-************ COMPGEN `prog  cmd help s` ************
+************ COMPGEN `prog cmd help s` ************
 suba
 subb
 

--- a/tests/snapshots/integration__compgen__one_combine_shorts.snap
+++ b/tests/snapshots/integration__compgen__one_combine_shorts.snap
@@ -2,7 +2,7 @@
 source: tests/compgen.rs
 expression: data
 ---
-************ COMPGEN `prog  -a` ************
+************ COMPGEN `prog -a` ************
 -a
 -ab
 

--- a/tests/snapshots/integration__compgen__option_multi_vals.snap
+++ b/tests/snapshots/integration__compgen__option_multi_vals.snap
@@ -2,13 +2,13 @@
 source: tests/compgen.rs
 expression: data
 ---
-************ COMPGEN `prog  --oa ` ************
+************ COMPGEN `prog --oa ` ************
 __argc_comp:dir
 
-************ COMPGEN `prog  --oa bash ` ************
+************ COMPGEN `prog --oa bash ` ************
 __argc_comp:file
 
-************ COMPGEN `prog  --oa bash cmd1 ` ************
+************ COMPGEN `prog --oa bash cmd1 ` ************
 __argc_comp:file
 
 

--- a/tests/snapshots/integration__compgen__shorts.snap
+++ b/tests/snapshots/integration__compgen__shorts.snap
@@ -2,7 +2,7 @@
 source: tests/compgen.rs
 expression: data
 ---
-************ COMPGEN `prog  ` ************
+************ COMPGEN `prog ` ************
 -a
 --fb
 -b
@@ -13,7 +13,7 @@ expression: data
 --oa
 -p
 
-************ COMPGEN `prog  -` ************
+************ COMPGEN `prog -` ************
 -a
 --fb
 -b
@@ -24,18 +24,18 @@ expression: data
 --oa
 -p
 
-************ COMPGEN `prog  --` ************
+************ COMPGEN `prog --` ************
 --fb
 --fc
 --oa
 
-************ COMPGEN `prog  -a` ************
+************ COMPGEN `prog -a` ************
 -ab
 -af
 -ae
 -ap
 
-************ COMPGEN `prog  -a ` ************
+************ COMPGEN `prog -a ` ************
 --fb
 -b
 --fc
@@ -45,13 +45,13 @@ expression: data
 --oa
 -p
 
-************ COMPGEN `prog  -af` ************
+************ COMPGEN `prog -af` ************
 -afb
 -aff
 -afe
 -afp
 
-************ COMPGEN `prog  -af ` ************
+************ COMPGEN `prog -af ` ************
 --fb
 -b
 --fc
@@ -61,25 +61,25 @@ expression: data
 --oa
 -p
 
-************ COMPGEN `prog  -ae` ************
+************ COMPGEN `prog -ae` ************
 
 
-************ COMPGEN `prog  -ae ` ************
+************ COMPGEN `prog -ae ` ************
 __argc_comp:file
 
-************ COMPGEN `prog  -abe` ************
+************ COMPGEN `prog -abe` ************
 
 
-************ COMPGEN `prog  -abe ` ************
+************ COMPGEN `prog -abe ` ************
 __argc_comp:file
 
-************ COMPGEN `prog  -s` ************
+************ COMPGEN `prog -s` ************
 -sa
 
-************ COMPGEN `prog  -sa` ************
+************ COMPGEN `prog -sa` ************
 
 
-************ COMPGEN `prog  -sa ` ************
+************ COMPGEN `prog -sa ` ************
 -a
 --fb
 -b

--- a/tests/snapshots/integration__compgen__subcmds.snap
+++ b/tests/snapshots/integration__compgen__subcmds.snap
@@ -2,31 +2,31 @@
 source: tests/compgen.rs
 expression: data
 ---
-************ COMPGEN `prog  ` ************
+************ COMPGEN `prog ` ************
 cmda
 cmdb
 [FILE]
 
-************ COMPGEN `prog  c` ************
+************ COMPGEN `prog c` ************
 cmda
 cmdb
 [FILE]
 
-************ COMPGEN `prog  cmda` ************
+************ COMPGEN `prog cmda` ************
 cmda
 
-************ COMPGEN `prog  cmda ` ************
+************ COMPGEN `prog cmda ` ************
 __argc_comp:file
 
-************ COMPGEN `prog  help ` ************
+************ COMPGEN `prog help ` ************
 cmda
 cmdb
 
-************ COMPGEN `prog  help c` ************
+************ COMPGEN `prog help c` ************
 cmda
 cmdb
 
-************ COMPGEN `prog  help cmda ` ************
+************ COMPGEN `prog help cmda ` ************
 
 
 


### PR DESCRIPTION
`argc --argc-compgen fish cargo.sh 'build '` => `argc --argc-compgen fish cargo.sh 'cargo build '` 