### PR TITLE
feat: compgen add `__argc_parts`

### DIFF
--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -350,6 +350,29 @@ arg() { :; }
 }
 
 #[test]
+fn parts() {
+    let script = r###"
+# @option --oa*[`_choice_fn`]
+_choice_fn() {
+    echo __argc_parts:/
+	echo A/B/C
+    echo A/C
+    echo B/C
+    echo C
+}
+"###;
+
+    snapshot_compgen!(
+        script,
+        vec![
+            vec!["prog", "--oa", ""],
+            vec!["prog", "--oa", "A/"],
+            vec!["prog", "--oa", "A/B/"],
+        ]
+    );
+}
+
+#[test]
 fn no_space() {
     let script = r###"
 # @option --oa*[`_choice_fn`]
@@ -376,4 +399,20 @@ _choice_fn() {
 "###;
 
     snapshot_compgen_shells!(script, vec!["prog", "--oa="]);
+}
+
+#[test]
+fn parts_shell() {
+    let script = r###"
+# @option --oa*[`_choice_fn`]
+_choice_fn() {
+    echo __argc_parts:/
+	echo A/B/C
+    echo A/C
+    echo B/C
+    echo C
+}
+"###;
+
+    snapshot_compgen_shells!(script, vec!["prog", "--oa", "A/"]);
 }

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -407,7 +407,7 @@ fn parts_shell() {
 # @option --oa*[`_choice_fn`]
 _choice_fn() {
     echo __argc_parts:/
-	echo A/B/C
+    echo A/B/C
     echo A/C
     echo B/C
     echo C

--- a/tests/snapshots/integration__compgen__parts.snap
+++ b/tests/snapshots/integration__compgen__parts.snap
@@ -1,0 +1,17 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog --oa ` ************
+A/
+B/
+C
+
+************ COMPGEN `prog --oa A/` ************
+A/B/
+A/C
+
+************ COMPGEN `prog --oa A/B/` ************
+A/B/C
+
+

--- a/tests/snapshots/integration__compgen__parts_shell.snap
+++ b/tests/snapshots/integration__compgen__parts_shell.snap
@@ -1,0 +1,33 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN Bash `prog --oa A/` ************
+ B/
+C 
+
+************ COMPGEN Elvish `prog --oa A/` ************
+A/B/	0	B/	
+A/C	1	C	
+
+************ COMPGEN Fish `prog --oa A/` ************
+A/B/
+A/C
+
+************ COMPGEN Nushell `prog --oa A/` ************
+A/B/
+A/C 
+
+************ COMPGEN Powershell `prog --oa A/` ************
+A/B/	0	B/	
+A/C	1	C	
+
+************ COMPGEN Xonsh `prog --oa A/` ************
+A/B/	0	B/	
+A/C	1	C	
+
+************ COMPGEN Zsh `prog --oa A/` ************
+A/B/	B/
+A/C 	C
+
+

--- a/tests/snapshots/integration__compgen__value_display.snap
+++ b/tests/snapshots/integration__compgen__value_display.snap
@@ -3,10 +3,7 @@ source: tests/compgen.rs
 expression: data
 ---
 ************ COMPGEN Bash `prog --oa=` ************
-abc:def:xyz 
-abc:def:tsr 
-abc:ijk:abc 
-abc:ijk:xyz 
+abc:
 
 ************ COMPGEN Elvish `prog --oa=` ************
 --oa=abc:def:xyz	1	abc:def:xyz	


### PR DESCRIPTION
creates an parts from values containing a specific separator.
```
_choice_fn() {
    echo __argc_parts:/
    echo A/B/C
    echo A/C
    echo B/C
    echo C
}
```
will generate candicates `A/` `B/` `C`
