### PR TITLE
Fix fish completions for path arguments

### DIFF
--- a/src/bin/argc/completions/argc.fish
+++ b/src/bin/argc/completions/argc.fish
@@ -2,7 +2,7 @@ function _argc_completer
     set -l words (commandline -o)
     set -l cmd $words[1]
     set -l scriptfile
-    if [ "$cmd" = "argc" ] 
+    if [ "$cmd" = "argc" ]
         set scriptfile (argc --argc-script-path 2>/dev/null)
     else
         set scriptfile (which "$cmd")
@@ -15,17 +15,17 @@ function _argc_completer
     if [ $cur = "" ]
         set -a words ''
     end
-    set -l candicates (argc --argc-compgen fish $scriptfile $words 2>/dev/null)
-    if test (count $candicates) -eq 1
-        if [ "$candicates[1]" = "__argc_comp:file" ]
-            __fish_complete_path
+    set -l candidates (argc --argc-compgen fish $scriptfile $words 2>/dev/null)
+    if test (count $candidates) -eq 1
+        if [ "$candidates[1]" = "__argc_comp:file" ]
+            __fish_complete_path $cur
             return
-        else if [ "$candicates[1]" = "__argc_comp:dir" ]
-            __fish_complete_directories 
+        else if [ "$candidates[1]" = "__argc_comp:dir" ]
+            __fish_complete_directories $cur
             return
         end
     end
-    for item in $candicates
+    for item in $candidates
         echo "$item"
     end
 end


### PR DESCRIPTION
The built-in `__fish_complete_directories` and `__fish_complete_path` functions require a prefix to operate on ([Source](https://fishshell.com/docs/current/completions.html)). By not providing this, it's not possible to tab-complete a path in a nested directory.

This PR simply adds the token begin completed to the function. This allows you to tab complete e.g. `argc some/deeply/nested/path`.