### PR TITLE
refactor: param fn must be called with __internal__ marker

### DIFF
--- a/src/bin/argc/parallel.rs
+++ b/src/bin/argc/parallel.rs
@@ -6,7 +6,7 @@ use std::process::{self, Command};
 use std::sync::mpsc::channel;
 use threadpool::ThreadPool;
 
-pub const PARALLEL_MODE: &str = "__parallel__";
+pub const PARALLEL_MODE: &str = "___parallel___";
 
 pub fn parallel(shell: &Path, script_file: &str, args: &[String]) -> Result<()> {
     let jobs = to_jobs(args);

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -8,6 +8,7 @@ use crate::argc_value::ArgcValue;
 use crate::matcher::Matcher;
 use crate::param::{FlagOptionParam, PositionalParam};
 use crate::parser::{parse, Event, EventData, EventScope, Position};
+use crate::utils::INTERNAL_MODE;
 use crate::Result;
 
 use anyhow::{bail, Context};
@@ -64,16 +65,16 @@ impl Command {
         if args.is_empty() {
             bail!("Invalid args");
         }
-        if args.len() >= 2 && self.root.borrow().exist_param_fn(args[1].as_str()) {
+        if args.len() >= 3 && args[1] == INTERNAL_MODE {
             let fallback_args = vec!["prog".to_string()];
-            let new_args = if args.len() == 2 {
+            let new_args = if args.len() == 3 {
                 &fallback_args
             } else {
-                &args[2..]
+                &args[3..]
             };
             let matcher = Matcher::new(self, new_args);
             let mut arg_values = matcher.to_arg_values_for_choice_fn();
-            arg_values.push(ArgcValue::ParamFn(args[1].clone()));
+            arg_values.push(ArgcValue::ParamFn(args[2].clone()));
             return Ok(arg_values);
         }
         let mut matcher = Matcher::new(self, args);

--- a/src/command/root_data.rs
+++ b/src/command/root_data.rs
@@ -41,8 +41,4 @@ impl RootData {
         }
         Ok(())
     }
-
-    pub(crate) fn exist_param_fn(&self, name: &str) -> bool {
-        self.choices_fns.iter().any(|(v, _)| v == name)
-    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,8 @@ use std::{
 };
 use which::which;
 
+pub const INTERNAL_MODE: &str = "___internal___";
+
 /// Transform into upper case string with an underscore between words. `foo-bar` => `FOO-BAR`
 pub fn to_cobol_case(value: &str) -> String {
     Converter::new()
@@ -95,6 +97,7 @@ pub fn run_param_fns(
                 process::Command::new(shell)
                     .args(shell_extra_args)
                     .arg(&script_file)
+                    .arg(INTERNAL_MODE)
                     .arg(&param_fn)
                     .args(args)
                     .envs(envs)

--- a/tests/param_fn.rs
+++ b/tests/param_fn.rs
@@ -5,10 +5,19 @@ fn case1() {
     snapshot_multi!(
         SCRIPT_OPTIONS,
         vec![
-            vec!["prog", "_choice_fn"],
-            vec!["prog", "_choice_fn", "prog", "cmda", "--cc", ""],
+            vec!["prog", "___internal___", "_choice_fn"],
             vec![
                 "prog",
+                "___internal___",
+                "_choice_fn",
+                "prog",
+                "cmda",
+                "--cc",
+                ""
+            ],
+            vec![
+                "prog",
+                "___internal___",
                 "_choice_fn",
                 "prog",
                 "cmda",
@@ -27,12 +36,37 @@ fn case2() {
     snapshot_multi!(
         SCRIPT_ARGS,
         vec![
-            vec!["prog", "_choice_fn"],
-            vec!["prog", "_choice_fn", "prog", "cmdl", ""],
-            vec!["prog", "_choice_fn", "prog", "cmdl", "v1"],
-            vec!["prog", "_choice_fn", "prog", "cmdl", "v1", ""],
-            vec!["prog", "_choice_fn", "prog", "cmdl", "v1", "v2"],
-            vec!["prog", "_choice_fn", "prog", "cmdl", "v1", "v2", ""],
+            vec!["prog", "___internal___", "_choice_fn"],
+            vec!["prog", "___internal___", "_choice_fn", "prog", "cmdl", ""],
+            vec!["prog", "___internal___", "_choice_fn", "prog", "cmdl", "v1"],
+            vec![
+                "prog",
+                "___internal___",
+                "_choice_fn",
+                "prog",
+                "cmdl",
+                "v1",
+                ""
+            ],
+            vec![
+                "prog",
+                "___internal___",
+                "_choice_fn",
+                "prog",
+                "cmdl",
+                "v1",
+                "v2"
+            ],
+            vec![
+                "prog",
+                "___internal___",
+                "_choice_fn",
+                "prog",
+                "cmdl",
+                "v1",
+                "v2",
+                ""
+            ],
         ]
     );
 }
@@ -50,12 +84,20 @@ _choice_fn() {
     snapshot_multi!(
         script,
         vec![
-            vec!["prog", "_choice_fn"],
-            vec!["prog", "_choice_fn", "prog", ""],
-            vec!["prog", "_choice_fn", "prog", "v1"],
-            vec!["prog", "_choice_fn", "prog", "v1", ""],
-            vec!["prog", "_choice_fn", "prog", "v1", "v2"],
-            vec!["prog", "_choice_fn", "prog", "v1", "v2", ""],
+            vec!["prog", "___internal___", "_choice_fn"],
+            vec!["prog", "___internal___", "_choice_fn", "prog", ""],
+            vec!["prog", "___internal___", "_choice_fn", "prog", "v1"],
+            vec!["prog", "___internal___", "_choice_fn", "prog", "v1", ""],
+            vec!["prog", "___internal___", "_choice_fn", "prog", "v1", "v2"],
+            vec![
+                "prog",
+                "___internal___",
+                "_choice_fn",
+                "prog",
+                "v1",
+                "v2",
+                ""
+            ],
         ]
     );
 }

--- a/tests/snapshots/integration__param_fn__case1.snap
+++ b/tests/snapshots/integration__param_fn__case1.snap
@@ -3,7 +3,7 @@ source: tests/param_fn.rs
 expression: data
 ---
 ************ RUN ************
-prog _choice_fn
+prog ___internal___ _choice_fn
 
 OUTPUT
 argc__args=( prog )
@@ -12,7 +12,7 @@ argc__positionals=(  )
 _choice_fn;exit;
 
 ************ RUN ************
-prog _choice_fn prog cmda --cc 
+prog ___internal___ _choice_fn prog cmda --cc 
 
 OUTPUT
 argc_cc=''
@@ -22,7 +22,7 @@ argc__positionals=(  )
 _choice_fn;exit;
 
 ************ RUN ************
-prog _choice_fn prog cmda -a --oa oa --cc 
+prog ___internal___ _choice_fn prog cmda -a --oa oa --cc 
 
 OUTPUT
 argc_a=1

--- a/tests/snapshots/integration__param_fn__case2.snap
+++ b/tests/snapshots/integration__param_fn__case2.snap
@@ -3,7 +3,7 @@ source: tests/param_fn.rs
 expression: data
 ---
 ************ RUN ************
-prog _choice_fn
+prog ___internal___ _choice_fn
 
 OUTPUT
 argc__args=( prog )
@@ -12,7 +12,7 @@ argc__positionals=(  )
 _choice_fn;exit;
 
 ************ RUN ************
-prog _choice_fn prog cmdl 
+prog ___internal___ _choice_fn prog cmdl 
 
 OUTPUT
 argc_val=( '' )
@@ -22,7 +22,7 @@ argc__positionals=( '' )
 _choice_fn '';exit;
 
 ************ RUN ************
-prog _choice_fn prog cmdl v1
+prog ___internal___ _choice_fn prog cmdl v1
 
 OUTPUT
 argc_val=( v1 )
@@ -32,7 +32,7 @@ argc__positionals=( v1 )
 _choice_fn v1;exit;
 
 ************ RUN ************
-prog _choice_fn prog cmdl v1 
+prog ___internal___ _choice_fn prog cmdl v1 
 
 OUTPUT
 argc_val=( v1 '' )
@@ -42,7 +42,7 @@ argc__positionals=( v1 '' )
 _choice_fn v1 '';exit;
 
 ************ RUN ************
-prog _choice_fn prog cmdl v1 v2
+prog ___internal___ _choice_fn prog cmdl v1 v2
 
 OUTPUT
 argc_val=( v1 v2 )
@@ -52,7 +52,7 @@ argc__positionals=( v1 v2 )
 _choice_fn v1 v2;exit;
 
 ************ RUN ************
-prog _choice_fn prog cmdl v1 v2 
+prog ___internal___ _choice_fn prog cmdl v1 v2 
 
 OUTPUT
 argc_val=( v1 v2 '' )

--- a/tests/snapshots/integration__param_fn__case3.snap
+++ b/tests/snapshots/integration__param_fn__case3.snap
@@ -3,7 +3,7 @@ source: tests/param_fn.rs
 expression: data
 ---
 ************ RUN ************
-prog _choice_fn
+prog ___internal___ _choice_fn
 
 OUTPUT
 argc__args=( prog )
@@ -12,7 +12,7 @@ argc__positionals=(  )
 _choice_fn;exit;
 
 ************ RUN ************
-prog _choice_fn prog 
+prog ___internal___ _choice_fn prog 
 
 OUTPUT
 argc_v1=''
@@ -22,7 +22,7 @@ argc__positionals=( '' )
 _choice_fn '';exit;
 
 ************ RUN ************
-prog _choice_fn prog v1
+prog ___internal___ _choice_fn prog v1
 
 OUTPUT
 argc_v1=v1
@@ -32,7 +32,7 @@ argc__positionals=( v1 )
 _choice_fn v1;exit;
 
 ************ RUN ************
-prog _choice_fn prog v1 
+prog ___internal___ _choice_fn prog v1 
 
 OUTPUT
 argc_v1=v1
@@ -43,7 +43,7 @@ argc__positionals=( v1 '' )
 _choice_fn v1 '';exit;
 
 ************ RUN ************
-prog _choice_fn prog v1 v2
+prog ___internal___ _choice_fn prog v1 v2
 
 OUTPUT
 argc_v1=v1
@@ -54,7 +54,7 @@ argc__positionals=( v1 v2 )
 _choice_fn v1 v2;exit;
 
 ************ RUN ************
-prog _choice_fn prog v1 v2 
+prog ___internal___ _choice_fn prog v1 v2 
 
 OUTPUT
 argc_v1=v1


### PR DESCRIPTION
```diff
- prog _choice_fn
+ prog ___internal___ _choice_fn
```

And all the function can be called in this way, not only function bind to parameter choice fn. good for test.