### PR TITLE
fix: allow muti char `/`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -490,7 +490,7 @@ fn parse_name(input: &str) -> nom::IResult<&str, &str> {
 }
 
 fn parse_multi_char(input: &str) -> nom::IResult<&str, char> {
-    one_of(",:;@|")(input)
+    one_of(",:;@|/")(input)
 }
 
 fn parse_default_value(input: &str) -> nom::IResult<&str, &str> {


### PR DESCRIPTION
```sh
# @option value*/[a|b|c]
```