### PR TITLE
feat: compgen add __argc_path macro

### DIFF
--- a/src/compgen.rs
+++ b/src/compgen.rs
@@ -89,8 +89,8 @@ pub fn compgen(
     let mut argc_cd = None;
     if let Some(fn_name) = argc_fn {
         let output = if script_path.is_empty() {
-            let mut values = vec![];
             // complete for argc
+            let mut values = vec![];
             if fn_name == "_choice_completion" {
                 if new_args.len() == 3 {
                     values.extend(Shell::list().map(|v| v.name().to_string()))
@@ -99,7 +99,7 @@ pub fn compgen(
                 if new_args.len() == 3 {
                     values.extend(Shell::list().map(|v| v.name().to_string()))
                 } else {
-                    values.push("__argc_value=file".to_string());
+                    values.push("__argc_value=path".to_string());
                 }
             }
             Some(values.join("\n"))
@@ -618,9 +618,9 @@ impl Shell {
     ) -> Option<(String, String, Vec<CandidateValue>)> {
         let (dir_only, exts) = if argc_value == "__argc_value=dir" {
             (true, None)
-        } else if argc_value == "__argc_value=file" {
+        } else if argc_value == "__argc_value=path" {
             (false, None)
-        } else if let Some(stripped_value) = argc_value.strip_prefix("__argc_value=file:") {
+        } else if let Some(stripped_value) = argc_value.strip_prefix("__argc_value=path:") {
             let exts: Vec<String> = stripped_value.split(',').map(|v| v.to_string()).collect();
             (false, Some(exts))
         } else {
@@ -842,13 +842,15 @@ fn parse_candidate_value(input: &str) -> CandidateValue {
 }
 
 fn convert_arg_value(value: &str) -> Option<String> {
-    if value.starts_with("file:") {
+    if value.starts_with("path:") {
         Some(format!("__argc_value={value}"))
+    } else if let Some(stripped_value) = value.strip_prefix("file:") {
+        Some(format!("__argc_value=path:{stripped_value}"))
     } else if ["path", "file", "arg", "any"]
         .iter()
         .any(|v| value.contains(v))
     {
-        Some("__argc_value=file".to_string())
+        Some("__argc_value=path".to_string())
     } else if value.contains("dir") || value.contains("folder") {
         Some("__argc_value=dir".to_string())
     } else {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -232,7 +232,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
             .iter()
             .any(|v| redirect_symbols.contains(&v.as_str()))
         {
-            return vec![("__argc_value=file".into(), String::new(), CompKind::Value)];
+            return vec![("__argc_value=path".into(), String::new(), CompKind::Value)];
         }
         let level = self.cmds.len() - 1;
         let mut last_cmd = self.cmds[level].1;
@@ -303,7 +303,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
             && !self.arg_comp.is_flag_or_option()
             && last_cmd.positional_params.is_empty()
         {
-            output.push(("__argc_value=file".into(), String::new(), CompKind::Value));
+            output.push(("__argc_value=path".into(), String::new(), CompKind::Value));
         }
         output
     }

--- a/tests/snapshots/integration__compgen__fallback_comp_file.snap
+++ b/tests/snapshots/integration__compgen__fallback_comp_file.snap
@@ -3,10 +3,10 @@ source: tests/compgen.rs
 expression: data
 ---
 ************ COMPGEN `prog args ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 ************ COMPGEN `prog args v` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 ************ COMPGEN `prog cmd --file ` ************
 __argc_value=FILE	/kind:value

--- a/tests/snapshots/integration__compgen__nested_subcmds.snap
+++ b/tests/snapshots/integration__compgen__nested_subcmds.snap
@@ -21,7 +21,7 @@ subb	/kind:command
 suba	/kind:command
 
 ************ COMPGEN `prog cmd suba ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 ************ COMPGEN `prog cmd help ` ************
 suba	/kind:command

--- a/tests/snapshots/integration__compgen__no_comp_subcmds.snap
+++ b/tests/snapshots/integration__compgen__no_comp_subcmds.snap
@@ -7,9 +7,9 @@ cmda	/kind:command
 cmdb	/kind:command
 
 ************ COMPGEN `prog cmdx ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 ************ COMPGEN `prog cmdx cmd` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 

--- a/tests/snapshots/integration__compgen__no_flags_options.snap
+++ b/tests/snapshots/integration__compgen__no_flags_options.snap
@@ -3,7 +3,7 @@ source: tests/compgen.rs
 expression: data
 ---
 ************ COMPGEN `prog no_arg ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 ************ COMPGEN `prog arg ` ************
 __argc_value=FILE	/kind:value

--- a/tests/snapshots/integration__compgen__no_param.snap
+++ b/tests/snapshots/integration__compgen__no_param.snap
@@ -3,6 +3,6 @@ source: tests/compgen.rs
 expression: data
 ---
 ************ COMPGEN `prog cmd ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 

--- a/tests/snapshots/integration__compgen__shorts.snap
+++ b/tests/snapshots/integration__compgen__shorts.snap
@@ -3,7 +3,7 @@ source: tests/compgen.rs
 expression: data
 ---
 ************ COMPGEN `prog ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 ************ COMPGEN `prog -` ************
 -a	/kind:flag
@@ -28,7 +28,7 @@ __argc_value=file	/kind:value
 -ap	/kind:option
 
 ************ COMPGEN `prog -a ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 ************ COMPGEN `prog -af` ************
 -afb	/kind:flag
@@ -37,7 +37,7 @@ __argc_value=file	/kind:value
 -afp	/kind:option
 
 ************ COMPGEN `prog -af ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 ************ COMPGEN `prog -ae` ************
 
@@ -58,6 +58,6 @@ __argc_value=FILE	/kind:value
 -sa	/kind:flag
 
 ************ COMPGEN `prog -sa ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 

--- a/tests/snapshots/integration__compgen__subcmds.snap
+++ b/tests/snapshots/integration__compgen__subcmds.snap
@@ -16,7 +16,7 @@ cmdb	/kind:command
 cmda	/kind:command
 
 ************ COMPGEN `prog cmda ` ************
-__argc_value=file	/kind:value
+__argc_value=path	/kind:value
 
 ************ COMPGEN `prog help ` ************
 cmda	/kind:command


### PR DESCRIPTION
__argc_path is the same as __argc_file, only with different semantics