### PR TITLE
feat: support profixed option

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -456,6 +456,17 @@ impl Command {
             .find(|v| v.name == name || v.is_match(name))
     }
 
+    pub(crate) fn find_prefixed_option(&self, name: &str) -> Option<(&FlagOptionParam, String)> {
+        for param in self.flag_option_params.iter() {
+            if let Some(prefix) = param.prefixed() {
+                if name.starts_with(&prefix) {
+                    return Some((param, prefix));
+                }
+            }
+        }
+        None
+    }
+
     pub(crate) fn match_version_short_name(&self) -> bool {
         match self.find_flag_option("-V") {
             Some(param) => &param.name == "version",

--- a/src/param.rs
+++ b/src/param.rs
@@ -243,6 +243,18 @@ impl FlagOptionParam {
         self.list_names().iter().any(|v| v == name)
     }
 
+    pub(crate) fn prefixed(&self) -> Option<String> {
+        if self.data.modifer != Modifier::Prefixed {
+            return None;
+        }
+
+        if let Some(ch) = self.short {
+            return Some(format!("-{ch}"));
+        }
+
+        Some(self.render_name())
+    }
+
     pub(crate) fn list_names(&self) -> Vec<String> {
         let mut output = vec![];
         output.push(format!("{}{}", self.render_hyphens(), self.name));
@@ -523,6 +535,7 @@ pub(crate) enum Modifier {
     MultiCharOptional(char),
     MultiCharRequired(char),
     Terminated,
+    Prefixed,
 }
 
 impl Modifier {
@@ -535,6 +548,7 @@ impl Modifier {
             Self::MultiCharOptional(_) => true,
             Self::MultiCharRequired(_) => true,
             Self::Terminated => true,
+            Self::Prefixed => true,
         }
     }
 
@@ -547,6 +561,7 @@ impl Modifier {
             Self::MultiCharOptional(_) => false,
             Self::MultiCharRequired(_) => true,
             Self::Terminated => false,
+            Self::Prefixed => false,
         }
     }
 
@@ -559,6 +574,7 @@ impl Modifier {
             Self::MultiCharOptional(c) => format!("*{c}"),
             Self::MultiCharRequired(c) => format!("+{c}"),
             Self::Terminated => "~".to_string(),
+            Self::Prefixed => "%".to_string(),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -345,6 +345,10 @@ fn parse_param_modifer(input: &str) -> nom::IResult<&str, ParamData> {
             arg.modifer = Modifier::Terminated;
             arg
         }),
+        map(terminated(parse_param_name, tag("%")), |mut arg| {
+            arg.modifer = Modifier::Prefixed;
+            arg
+        }),
         map(
             pair(parse_param_name, preceded(tag("*"), opt(parse_multi_char))),
             |(mut arg, multi_char)| {
@@ -800,6 +804,7 @@ mod tests {
         assert_parse_option_arg!("-f![a|b]");
         assert_parse_option_arg!("-f![`_foo`]");
         assert_parse_option_arg!("-f![=a|b]");
+        assert_parse_option_arg!("-D%");
     }
 
     #[test]

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -530,6 +530,31 @@ _choice_fn() {
 }
 
 #[test]
+fn option_prefixed() {
+    let script = r###"
+# @option -D%[`_choice_fn`]
+# @option -X --ox%[`_choice_fn`]
+_choice_fn() {
+    echo VAR1=value1 
+    echo VAR2=value2
+    echo VAR3
+}
+"###;
+
+    snapshot_compgen!(
+        script,
+        vec![
+            vec!["prog", "-D"],
+            vec!["prog", "-DVAR1"],
+            vec!["prog", "-X"],
+            vec!["prog", "-XVAR1"],
+            vec!["prog", "--ox"],
+            vec!["prog", "--ox", "VAR1"],
+        ]
+    );
+}
+
+#[test]
 fn last_arg_option_assign() {
     let script = r###"
 # @option --oa~[`_choice_fn`]

--- a/tests/snapshots/integration__compgen__option_prefixed.snap
+++ b/tests/snapshots/integration__compgen__option_prefixed.snap
@@ -1,0 +1,27 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog -D` ************
+VAR1=value1	/color:green
+VAR2=value2	/color:green
+VAR3	/color:green
+
+************ COMPGEN `prog -DVAR1` ************
+VAR1=value1	/color:green
+
+************ COMPGEN `prog -X` ************
+VAR1=value1	/color:green
+VAR2=value2	/color:green
+VAR3	/color:green
+
+************ COMPGEN `prog -XVAR1` ************
+VAR1=value1	/color:green
+
+************ COMPGEN `prog --ox` ************
+--ox	/color:cyan,bold
+
+************ COMPGEN `prog --ox VAR1` ************
+VAR1=value1	/color:green
+
+

--- a/tests/snapshots/integration__spec__option_prefixed.snap
+++ b/tests/snapshots/integration__spec__option_prefixed.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec.rs
+expression: data
+---
+RUN
+prog -D v1 -Dv2=foo
+
+OUTPUT
+argc_D=( v1 'v2=foo' )
+argc__args=( prog -D v1 '-Dv2=foo' )
+argc__index=0
+argc__positionals=(  )
+

--- a/tests/snapshots/integration__spec__option_terminated.snap
+++ b/tests/snapshots/integration__spec__option_terminated.snap
@@ -1,0 +1,13 @@
+---
+source: tests/spec.rs
+expression: data
+---
+RUN
+prog --oa bash Argcfile.sh --ob
+
+OUTPUT
+argc_oa=( bash Argcfile.sh --ob )
+argc__args=( prog --oa bash Argcfile.sh --ob )
+argc__index=0
+argc__positionals=(  )
+

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -186,3 +186,20 @@ fn option_to_variable() {
         ]
     );
 }
+
+#[test]
+fn option_terminated() {
+    let script = r###"
+# @option --oa~ <SHELL> <SCRIPT> <ARGS...> 
+# @option --ob
+"###;
+    snapshot!(script, &["prog", "--oa", "bash", "Argcfile.sh", "--ob"]);
+}
+
+#[test]
+fn option_prefixed() {
+    let script = r###"
+# @option -D%
+"###;
+    snapshot!(script, &["prog", "-D", "v1", "-Dv2=foo"]);
+}


### PR DESCRIPTION
`cmake -D` or `java -X` are prefixed option.

argc use modifier `%` to mark a option is prefixed option.

```sh
# @option -D% <var>[:<type>]=<value>    Create or update a cmake cache entry.
```
```
$ prog  -DVAR1=value1 -DVAR2=value2
```