### PR TITLE
feat: support flag command

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -32,7 +32,7 @@ pub fn export(source: &str) -> Result<serde_json::Value> {
     cmd.to_json().with_context(|| "Failed to export json")
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Command {
     pub(crate) name: Option<String>,
     pub(crate) fn_name: Option<String>,

--- a/src/command/root_data.rs
+++ b/src/command/root_data.rs
@@ -3,7 +3,7 @@ use crate::parser::{EventScope, Position};
 use anyhow::{bail, Result};
 use std::collections::HashMap;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub(crate) struct RootData {
     pub(crate) scope: EventScope,
     pub(crate) fns: HashMap<String, Position>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -46,7 +46,7 @@ pub(crate) enum EventData {
     Unknown(String),
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum EventScope {
     Root,
     CmdStart,

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -119,6 +119,41 @@ cmd::subb() { :; }
 }
 
 #[test]
+fn flag_cmds() {
+    const SCRIPT: &str = r###"
+# @option -G
+
+# @cmd Run --foo
+# @alias -F
+# @flag --fa
+--foo() {
+    :;
+}
+
+# @cmd Run bar
+# @alias -B
+# @flag -C
+# @flag -D
+# @flag --fa
+bar() {
+    :;
+}
+"###;
+
+    snapshot_compgen!(
+        SCRIPT,
+        vec![
+            vec!["prog", ""],
+            vec!["prog", "-"],
+            vec!["prog", "-B"],
+            vec!["prog", "-B", "-"],
+            vec!["prog", "-BC"],
+            vec!["prog", "-G"],
+        ]
+    );
+}
+
+#[test]
 fn positionals() {
     let script = r###"
 # @cmd

--- a/tests/snapshots/integration__compgen__flag_cmds.snap
+++ b/tests/snapshots/integration__compgen__flag_cmds.snap
@@ -1,0 +1,30 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog ` ************
+bar	/color:magenta	Run bar
+
+************ COMPGEN `prog -` ************
+-G	/color:cyan,bold
+--foo	/color:magenta	Run --foo
+-F	/color:magenta	Run --foo
+-B	/color:magenta	Run bar
+
+************ COMPGEN `prog -B` ************
+-BC	/color:cyan
+-BD	/color:cyan
+
+************ COMPGEN `prog -B -` ************
+-C	/color:cyan
+-D	/color:cyan
+--fa	/color:cyan
+
+************ COMPGEN `prog -BC` ************
+-BC	/color:cyan
+-BCD	/color:cyan
+
+************ COMPGEN `prog -G` ************
+-G	/color:cyan,bold
+
+

--- a/tests/snapshots/integration__compgen__just_match.snap
+++ b/tests/snapshots/integration__compgen__just_match.snap
@@ -3,7 +3,7 @@ source: tests/compgen.rs
 expression: data
 ---
 ************ COMPGEN `prog --oa` ************
---oa-file	/color:cyan,bold
 --oa	/color:cyan,bold
+--oa-file	/color:cyan,bold
 
 

--- a/tests/snapshots/integration__spec__cmd_combine_shorts.snap
+++ b/tests/snapshots/integration__spec__cmd_combine_shorts.snap
@@ -1,0 +1,26 @@
+---
+source: tests/spec.rs
+expression: data
+---
+************ RUN ************
+prog -A
+
+OUTPUT
+argc__args=( prog -A )
+argc__index=1
+argc__fn=-A
+argc__positionals=(  )
+-A
+
+************ RUN ************
+prog -AB
+
+OUTPUT
+argc_B=1
+argc__args=( prog -AB )
+argc__index=1
+argc__fn=-A
+argc__positionals=(  )
+-A
+
+

--- a/tests/snapshots/integration__spec__cmd_with_hyphen.snap
+++ b/tests/snapshots/integration__spec__cmd_with_hyphen.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec.rs
+expression: data
+---
+************ RUN ************
+prog --foo --fa
+
+OUTPUT
+argc_fa=1
+argc__args=( prog --foo --fa )
+argc__index=1
+argc__fn=--foo
+argc__positionals=(  )
+--foo
+
+************ RUN ************
+prog -B --fa
+
+OUTPUT
+argc_fa=1
+argc__args=( prog -B --fa )
+argc__index=1
+argc__fn=bar
+argc__positionals=(  )
+bar
+
+

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -203,3 +203,38 @@ fn option_prefixed() {
 "###;
     snapshot!(script, &["prog", "-D", "v1", "-Dv2=foo"]);
 }
+
+#[test]
+fn cmd_with_hyphen() {
+    let script = r###"
+# @cmd Run --foo
+# @flag --fa
+--foo() {
+    :;
+}
+
+# @cmd Run bar
+# @alias -B
+# @flag --fa
+bar() {
+    :;
+}
+"###;
+    snapshot_multi!(
+        script,
+        vec![vec!["prog", "--foo", "--fa"], vec!["prog", "-B", "--fa"]]
+    );
+}
+
+#[test]
+fn cmd_combine_shorts() {
+    let script = r###"
+# @cmd
+# @flag -B
+# @flag -C
+-A() {
+    :;
+}
+"###;
+    snapshot_multi!(script, vec![vec!["prog", "-A"], vec!["prog", "-AB"]]);
+}


### PR DESCRIPTION
Flag command has command name startsWith `-`. 
Use pacman as example:

```sh
# @cmd
# @alias -Q
# @option -i  --info           view package information (-ii for backup files)
--query() {
  :;
}

# @cmd
# @alias -S
# @option  -s  --search <regex> search remote repositories for matching strings
--sync() {
  :;
}
```

```
$ pacman -Qi vim

$ pacman -Ss '^vim-'
```