### PR TITLE
feat: sanitize command name

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -942,12 +942,7 @@ fn match_command<'a, 'b>(
     arg_index: usize,
 ) {
     *cmd_level += 1;
-    cmds.push((
-        arg,
-        subcmd,
-        subcmd.name.clone().unwrap_or_else(|| arg.to_string()),
-        arg_index,
-    ));
+    cmds.push((arg, subcmd, arg.to_string(), arg_index));
     flag_option_args.push(vec![]);
 }
 

--- a/tests/snapshots/integration__validate__cmd_name_sanitize.snap
+++ b/tests/snapshots/integration__validate__cmd_name_sanitize.snap
@@ -1,0 +1,88 @@
+---
+source: tests/validate.rs
+expression: data
+---
+************ RUN ************
+prog --help
+
+OUTPUT
+command cat >&2 <<-'EOF' 
+USAGE: prog <COMMAND>
+
+COMMANDS:
+  cat
+  do
+  foo-bar
+
+EOF
+exit 0
+
+************ RUN ************
+prog cat --help
+
+OUTPUT
+command cat >&2 <<-'EOF' 
+USAGE: prog cat
+
+EOF
+exit 0
+
+************ RUN ************
+prog cat
+
+OUTPUT
+argc__args=( prog cat )
+argc__index=1
+argc__fn=cat_
+argc__positionals=(  )
+cat_
+
+************ RUN ************
+prog do --help
+
+OUTPUT
+command cat >&2 <<-'EOF' 
+USAGE: prog do <COMMAND>
+
+COMMANDS:
+  foo
+  bar
+
+EOF
+exit 0
+
+************ RUN ************
+prog do
+
+OUTPUT
+command cat >&2 <<-'EOF' 
+USAGE: prog do <COMMAND>
+
+COMMANDS:
+  foo
+  bar
+
+EOF
+exit 0
+
+************ RUN ************
+prog do foo
+
+OUTPUT
+argc__args=( prog do foo )
+argc__index=2
+argc__fn=do_::foo
+argc__positionals=(  )
+do_::foo
+
+************ RUN ************
+prog foo-bar
+
+OUTPUT
+argc__args=( prog foo-bar )
+argc__index=1
+argc__fn=foo_bar
+argc__positionals=(  )
+foo_bar
+
+

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -212,3 +212,45 @@ _choice_fn() {
 "###;
     snapshot_multi!(script, vec![vec!["prog", "cmd", "a\\b", "a\\b"],]);
 }
+
+#[test]
+fn cmd_name_sanitize() {
+    let script = r###"
+# @cmd
+cat_() {
+    echo run cat_
+}
+
+# @cmd
+do_() {
+    echo run do_
+}
+
+# @cmd
+do_::foo() {
+    echo run do_::foo
+}
+
+# @cmd
+do_::bar() {
+    echo run do_::bar
+}
+
+# @cmd
+foo_bar() {
+    echo run foo_bar
+}
+"###;
+    snapshot_multi!(
+        script,
+        vec![
+            vec!["prog", "--help"],
+            vec!["prog", "cat", "--help"],
+            vec!["prog", "cat"],
+            vec!["prog", "do", "--help"],
+            vec!["prog", "do"],
+            vec!["prog", "do", "foo"],
+            vec!["prog", "foo-bar"],
+        ]
+    );
+}


### PR DESCRIPTION
With this pr, we can bypass bash keyword restrictions to define commands(such as `do`, `cat`, `if`) with `_` suffix.

```
# @cmd
cat_() {
    echo run cat_
}

# @cmd
do_() {
    echo run do_
}

# @cmd
do_::foo() {
    echo run do_::foo
}

# @cmd
do_::bar() {
    echo run do_::bar
}

# @cmd
foo_bar() {
    echo run foo_bar
}
```

```
$ argc --help
USAGE: Argcfile.sh <COMMAND>

COMMANDS:
  cat
  do
  foo-bar
```
```
$ argc cat
run cat_
```
