### PR TITLE
fix: sanitize command name don't replace _ to -

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -618,7 +618,7 @@ fn retrive_cmd<'a>(cmd: &'a mut Command, cmd_paths: &[String]) -> Option<&'a mut
 }
 
 fn sanitize_cmd_name(name: &str) -> String {
-    name.trim_end_matches('_').replace('_', "-")
+    name.trim_end_matches('_').to_string()
 }
 
 fn wrap_render_block(name: &str, describe: &str, term_width: Option<usize>) -> String {

--- a/tests/snapshots/integration__validate__cmd_name_sanitize.snap
+++ b/tests/snapshots/integration__validate__cmd_name_sanitize.snap
@@ -12,7 +12,6 @@ USAGE: prog <COMMAND>
 COMMANDS:
   cat
   do
-  foo-bar
 
 EOF
 exit 0
@@ -74,15 +73,5 @@ argc__index=2
 argc__fn=do_::foo
 argc__positionals=(  )
 do_::foo
-
-************ RUN ************
-prog foo-bar
-
-OUTPUT
-argc__args=( prog foo-bar )
-argc__index=1
-argc__fn=foo_bar
-argc__positionals=(  )
-foo_bar
 
 

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -235,11 +235,6 @@ do_::foo() {
 do_::bar() {
     echo run do_::bar
 }
-
-# @cmd
-foo_bar() {
-    echo run foo_bar
-}
 "###;
     snapshot_multi!(
         script,
@@ -250,7 +245,6 @@ foo_bar() {
             vec!["prog", "do", "--help"],
             vec!["prog", "do"],
             vec!["prog", "do", "foo"],
-            vec!["prog", "foo-bar"],
         ]
     );
 }


### PR DESCRIPTION
related #223 , cmd name `foo_bar` won't change to `foo-bar`
