### PR TITLE
refactor: use tailing '-' to mark prefixed option

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -574,7 +574,7 @@ impl Modifier {
             Self::MultiCharOptional(c) => format!("*{c}"),
             Self::MultiCharRequired(c) => format!("+{c}"),
             Self::Terminated => "~".to_string(),
-            Self::Prefixed => "%".to_string(),
+            Self::Prefixed => "-".to_string(),
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -345,10 +345,6 @@ fn parse_param_modifer(input: &str) -> nom::IResult<&str, ParamData> {
             arg.modifer = Modifier::Terminated;
             arg
         }),
-        map(terminated(parse_param_name, tag("%")), |mut arg| {
-            arg.modifer = Modifier::Prefixed;
-            arg
-        }),
         map(
             pair(parse_param_name, preceded(tag("*"), opt(parse_multi_char))),
             |(mut arg, multi_char)| {
@@ -371,7 +367,13 @@ fn parse_param_modifer(input: &str) -> nom::IResult<&str, ParamData> {
                 arg
             },
         ),
-        parse_param_name,
+        map(parse_param_name, |mut arg| {
+            if arg.name.ends_with("-") {
+                arg.name = arg.name.trim_end_matches("-").to_string();
+                arg.modifer = Modifier::Prefixed;
+            }
+            arg
+        }),
     ))(input)
 }
 
@@ -806,7 +808,7 @@ mod tests {
         assert_parse_option_arg!("-f![a|b]");
         assert_parse_option_arg!("-f![`_foo`]");
         assert_parse_option_arg!("-f![=a|b]");
-        assert_parse_option_arg!("-D%");
+        assert_parse_option_arg!("-D-");
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -368,8 +368,8 @@ fn parse_param_modifer(input: &str) -> nom::IResult<&str, ParamData> {
             },
         ),
         map(parse_param_name, |mut arg| {
-            if arg.name.ends_with("-") {
-                arg.name = arg.name.trim_end_matches("-").to_string();
+            if let Some(name) = arg.name.strip_suffix('-') {
+                arg.name = name.to_string();
                 arg.modifer = Modifier::Prefixed;
             }
             arg
@@ -809,6 +809,7 @@ mod tests {
         assert_parse_option_arg!("-f![`_foo`]");
         assert_parse_option_arg!("-f![=a|b]");
         assert_parse_option_arg!("-D-");
+        assert_parse_option_arg!("-D--");
     }
 
     #[test]

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -567,8 +567,8 @@ _choice_fn() {
 #[test]
 fn option_prefixed() {
     let script = r###"
-# @option -D%[`_choice_fn`]
-# @option -X --ox%[`_choice_fn`]
+# @option -D-[`_choice_fn`]
+# @option -X --ox-[`_choice_fn`]
 _choice_fn() {
     echo VAR1=value1 
     echo VAR2=value2

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -199,7 +199,7 @@ fn option_terminated() {
 #[test]
 fn option_prefixed() {
     let script = r###"
-# @option -D%
+# @option -D-
 "###;
     snapshot!(script, &["prog", "-D", "v1", "-Dv2=foo"]);
 }


### PR DESCRIPTION
related to #219

change `%` to `-`

```sh
# @option -D- <var>[:<type>]=<value>    Create or update a cmake cache entry.
```
```
$ prog  -DVAR1=value1 -DVAR2=value2
```