### PR TITLE
feat: support @meta inherit-flag-options

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -544,13 +544,17 @@ impl Command {
 
     fn inherit_flag_options(&mut self) {
         for subcmd in self.subcommands.iter_mut() {
+            let mut inherited_flag_options = vec![];
             for flag_option in &self.flag_option_params {
                 if subcmd.find_flag_option(flag_option.name()).is_none() {
                     let mut flag_option = flag_option.clone();
                     flag_option.inherit = true;
-                    subcmd.flag_option_params.push(flag_option)
+                    inherited_flag_options.push(flag_option);
                 }
             }
+            subcmd
+                .flag_option_params
+                .splice(..0, inherited_flag_options);
         }
         for subcmd in self.subcommands.iter_mut() {
             subcmd.inherit_flag_options();

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -98,7 +98,6 @@ impl Command {
         let flag_option_params: Vec<serde_json::Value> = self
             .flag_option_params
             .iter()
-            .filter(|v| !v.inherit)
             .map(|v| v.to_json())
             .collect();
         let positional_params: Vec<serde_json::Value> =

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -48,13 +48,17 @@ pub struct Command {
     pub(crate) names_checker: NamesChecker,
     pub(crate) root: Arc<RefCell<RootData>>,
     pub(crate) aliases: Vec<String>,
-    pub(crate) metadatas: IndexMap<String, (String, Position)>,
+    pub(crate) metadata: IndexMap<String, (String, Position)>,
 }
 
 impl Command {
     pub fn new(source: &str) -> Result<Self> {
         let events = parse(source)?;
-        Command::new_from_events(&events)
+        let mut root = Command::new_from_events(&events)?;
+        if root.metadata.contains_key("inherit-flag-options") {
+            root.inherit_flag_options();
+        }
+        Ok(root)
     }
 
     pub fn eval(
@@ -94,21 +98,22 @@ impl Command {
         let flag_option_params: Vec<serde_json::Value> = self
             .flag_option_params
             .iter()
+            .filter(|v| !v.inherit)
             .map(|v| v.to_json())
             .collect();
         let positional_params: Vec<serde_json::Value> =
             self.positional_params.iter().map(|v| v.to_json()).collect();
-        let mut metadatas = serde_json::Map::new();
-        for (k, (v, _)) in &self.metadatas {
-            metadatas.insert(k.to_string(), serde_json::Value::String(v.to_string()));
+        let mut metadata = serde_json::Map::new();
+        for (k, (v, _)) in &self.metadata {
+            metadata.insert(k.to_string(), serde_json::Value::String(v.to_string()));
         }
-        let metadatas = serde_json::Value::Object(metadatas);
+        let metadata = serde_json::Value::Object(metadata);
         serde_json::json!({
             "describe": self.describe,
             "name": self.name,
             "author": self.author,
             "version": self.version,
-            "metadatas": metadatas,
+            "metadata": metadata,
             "options": flag_option_params,
             "positionals": positional_params,
             "aliases": self.aliases,
@@ -136,7 +141,7 @@ impl Command {
                 }
                 EventData::Meta(key, value) => {
                     let cmd = Self::get_cmd(&mut root_cmd, "@meta", position)?;
-                    if let Some((_, pos)) = cmd.metadatas.get(&key) {
+                    if let Some((_, pos)) = cmd.metadata.get(&key) {
                         bail!(
                             "@meta(line {}) conflicts with '{}' at line {}",
                             position,
@@ -144,7 +149,7 @@ impl Command {
                             pos
                         )
                     }
-                    cmd.metadatas.insert(key, (value, position));
+                    cmd.metadata.insert(key, (value, position));
                 }
                 EventData::Cmd(value) => {
                     if root_data.borrow().scope == EventScope::CmdStart {
@@ -535,6 +540,21 @@ impl Command {
         self.get_cmd_fn(cmd_paths)
             .map(|v| v.ends_with("main"))
             .unwrap_or_default()
+    }
+
+    fn inherit_flag_options(&mut self) {
+        for subcmd in self.subcommands.iter_mut() {
+            for flag_option in &self.flag_option_params {
+                if subcmd.find_flag_option(flag_option.name()).is_none() {
+                    let mut flag_option = flag_option.clone();
+                    flag_option.inherit = true;
+                    subcmd.flag_option_params.push(flag_option)
+                }
+            }
+        }
+        for subcmd in self.subcommands.iter_mut() {
+            subcmd.inherit_flag_options();
+        }
     }
 
     fn add_positional_param(&mut self, param: PositionalParam, pos: Position) -> Result<()> {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -65,7 +65,7 @@ pub(crate) enum MatchError {
 
 impl<'a, 'b> Matcher<'a, 'b> {
     pub(crate) fn new(root: &'a Command, args: &'b [String]) -> Self {
-        let combine_shorts = root.metadatas.contains_key("combine-shorts");
+        let combine_shorts = root.metadata.contains_key("combine-shorts");
         let mut cmds: Vec<LevelCommand> = vec![(args[0].as_str(), root, args[0].clone(), 0)];
         let mut cmd_level = 0;
         let mut arg_index = 1;

--- a/src/param.rs
+++ b/src/param.rs
@@ -15,6 +15,7 @@ pub(crate) struct FlagOptionParam {
     pub(crate) data: ParamData,
     pub(crate) value_names: Vec<String>,
     pub(crate) arg_value_names: Vec<String>,
+    pub(crate) inherit: bool,
 }
 
 impl FlagOptionParam {
@@ -41,6 +42,7 @@ impl FlagOptionParam {
             data: param,
             value_names,
             arg_value_names,
+            inherit: false,
         }
     }
 

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -450,6 +450,32 @@ _choice_fn() {
 }
 
 #[test]
+fn inherit_flag_options() {
+    let script = r###"
+# @meta inherit-flag-options
+# @flag --oa
+# @option --ob[a|b]  desc 1
+
+# @cmd
+cmda() {
+    :;
+}
+
+# @cmd
+# @option --ob[x|y]  desc 2
+cmdb() {
+    :;
+}
+"###;
+    snapshot_compgen!(
+        script,
+        [vec!["prog", "cmda", "--"], vec!["prog", "cmdb", "--"]]
+    );
+}
+
+// ------------ compgen shell -----------
+
+#[test]
 fn no_space() {
     let script = r#"
 # @option --oa*[`_choice_fn`]

--- a/tests/snapshots/integration__compgen__inherit_flag_options.snap
+++ b/tests/snapshots/integration__compgen__inherit_flag_options.snap
@@ -7,7 +7,7 @@ expression: data
 --ob	/color:cyan,bold	desc 1
 
 ************ COMPGEN `prog cmdb --` ************
---ob	/color:cyan,bold	desc 2
 --oa	/color:cyan
+--ob	/color:cyan,bold	desc 2
 
 

--- a/tests/snapshots/integration__compgen__inherit_flag_options.snap
+++ b/tests/snapshots/integration__compgen__inherit_flag_options.snap
@@ -1,0 +1,13 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog cmda --` ************
+--oa	/color:cyan
+--ob	/color:cyan,bold	desc 1
+
+************ COMPGEN `prog cmdb --` ************
+--ob	/color:cyan,bold	desc 2
+--oa	/color:cyan
+
+

--- a/tests/snapshots/integration__export__case1.snap
+++ b/tests/snapshots/integration__export__case1.snap
@@ -7,7 +7,7 @@ expression: output
   "name": null,
   "author": "nobody <nobody@example.com>",
   "version": "1.0.0",
-  "metadatas": {
+  "metadata": {
     "combine-shorts": ""
   },
   "options": [],
@@ -19,7 +19,7 @@ expression: output
       "name": "cmd",
       "author": null,
       "version": null,
-      "metadatas": {},
+      "metadata": {},
       "options": [
         {
           "name": "fa",

--- a/tests/snapshots/integration__spec__inherit_flag_options.snap
+++ b/tests/snapshots/integration__spec__inherit_flag_options.snap
@@ -1,0 +1,27 @@
+---
+source: tests/spec.rs
+expression: data
+---
+************ RUN ************
+prog cmda --ob a
+
+OUTPUT
+argc_ob=a
+argc__args=( prog cmda --ob a )
+argc__cmd_arg_index=1
+argc__fn=cmda
+argc__positionals=(  )
+cmda
+
+************ RUN ************
+prog cmdb --ob x
+
+OUTPUT
+argc_ob=x
+argc__args=( prog cmdb --ob x )
+argc__cmd_arg_index=1
+argc__fn=cmdb
+argc__positionals=(  )
+cmdb
+
+

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -249,3 +249,30 @@ fn name_with_special_chars() {
 "###;
     snapshot_multi!(script, [vec!["prog", "--fa:foo", "--fa.bar", "--fa_baz"]]);
 }
+
+#[test]
+fn inherit_flag_options() {
+    let script = r###"
+# @meta inherit-flag-options
+# @flag --oa
+# @option --ob[a|b]  desc 1
+
+# @cmd
+cmda() {
+    :;
+}
+
+# @cmd
+# @option --ob[x|y]  desc 2
+cmdb() {
+    :;
+}
+"###;
+    snapshot_multi!(
+        script,
+        [
+            vec!["prog", "cmda", "--ob", "a"],
+            vec!["prog", "cmdb", "--ob", "x"]
+        ]
+    );
+}


### PR DESCRIPTION
with `# @meta inherit-flag-options`, subcommand will inherit flag options of parent command.