### PR TITLE
feat: support symbol parameter

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -7,11 +7,11 @@ use self::root_data::RootData;
 use crate::argc_value::ArgcValue;
 use crate::matcher::Matcher;
 use crate::param::{FlagOptionParam, PositionalParam};
-use crate::parser::{parse, Event, EventData, EventScope, Position};
+use crate::parser::{parse, parse_symbol, Event, EventData, EventScope, Position};
 use crate::utils::INTERNAL_MODE;
 use crate::Result;
 
-use anyhow::bail;
+use anyhow::{anyhow, bail};
 use indexmap::IndexMap;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -48,14 +48,15 @@ pub struct Command {
     pub(crate) names_checker: NamesChecker,
     pub(crate) root: Arc<RefCell<RootData>>,
     pub(crate) aliases: Vec<String>,
-    pub(crate) metadata: IndexMap<String, (String, Position)>,
+    pub(crate) metadata: Vec<(String, String, Position)>,
+    pub(crate) symbols: IndexMap<char, SymbolParam>,
 }
 
 impl Command {
     pub fn new(source: &str) -> Result<Self> {
         let events = parse(source)?;
         let mut root = Command::new_from_events(&events)?;
-        if root.metadata.contains_key("inherit-flag-options") {
+        if root.has_metadata("inherit-flag-options") {
             root.inherit_flag_options();
         }
         Ok(root)
@@ -102,11 +103,8 @@ impl Command {
             .collect();
         let positional_params: Vec<serde_json::Value> =
             self.positional_params.iter().map(|v| v.to_json()).collect();
-        let mut metadata = serde_json::Map::new();
-        for (k, (v, _)) in &self.metadata {
-            metadata.insert(k.to_string(), serde_json::Value::String(v.to_string()));
-        }
-        let metadata = serde_json::Value::Object(metadata);
+        let metadata: Vec<Vec<&String>> =
+            self.metadata.iter().map(|(k, v, _)| vec![k, v]).collect();
         serde_json::json!({
             "describe": self.describe,
             "name": self.name,
@@ -140,15 +138,14 @@ impl Command {
                 }
                 EventData::Meta(key, value) => {
                     let cmd = Self::get_cmd(&mut root_cmd, "@meta", position)?;
-                    if let Some((_, pos)) = cmd.metadata.get(&key) {
-                        bail!(
-                            "@meta(line {}) conflicts with '{}' at line {}",
-                            position,
-                            key,
-                            pos
-                        )
+                    if key == "symbol" {
+                        let (ch, name, choice_fn) = parse_symbol(&value).ok_or_else(|| {
+                            anyhow!("@meta(line {}) invalid symbol '{}'", position, value,)
+                        })?;
+                        cmd.symbols
+                            .insert(ch, (name.to_string(), choice_fn.map(|v| v.to_string())));
                     }
-                    cmd.metadata.insert(key, (value, position));
+                    cmd.metadata.push((key, value, position));
                 }
                 EventData::Cmd(value) => {
                     if root_data.borrow().scope == EventScope::CmdStart {
@@ -268,6 +265,10 @@ impl Command {
         }
         root_cmd.root.borrow().check_param_fn()?;
         Ok(root_cmd)
+    }
+
+    pub(crate) fn has_metadata(&self, key: &str) -> bool {
+        self.metadata.iter().any(|(k, _, _)| k == key)
     }
 
     pub(crate) fn render_help(&self, cmd_paths: &[&str], term_width: Option<usize>) -> String {
@@ -643,6 +644,8 @@ impl Command {
         ));
     }
 }
+
+pub(crate) type SymbolParam = (String, Option<String>);
 
 fn retrive_cmd<'a>(cmd: &'a mut Command, cmd_paths: &[String]) -> Option<&'a mut Command> {
     if cmd_paths.is_empty() {

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -140,7 +140,7 @@ impl Command {
                     let cmd = Self::get_cmd(&mut root_cmd, "@meta", position)?;
                     if key == "symbol" {
                         let (ch, name, choice_fn) = parse_symbol(&value).ok_or_else(|| {
-                            anyhow!("@meta(line {}) invalid symbol '{}'", position, value,)
+                            anyhow!("@meta(line {}) invalid symbol value", position)
                         })?;
                         cmd.symbols
                             .insert(ch, (name.to_string(), choice_fn.map(|v| v.to_string())));

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -80,6 +80,25 @@ fn shorts() {
 }
 
 #[test]
+fn symbol() {
+    let script = r###"
+# @meta symbol +toolchain[`_choice_fn`]
+# @meta symbol @file
+# @option --oa
+
+_choice_fn() {
+    echo stable
+    echo beta
+    echo nightly
+}
+"###;
+    snapshot_compgen!(
+        script,
+        [vec!["prog", "+"], vec!["prog", "@"], vec!["prog", "+s"]]
+    );
+}
+
+#[test]
 fn subcmds() {
     const SCRIPT: &str = r###"
 # @arg file

--- a/tests/snapshots/integration__compgen__symbol.snap
+++ b/tests/snapshots/integration__compgen__symbol.snap
@@ -1,0 +1,16 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog +` ************
+stable	/color:default
+beta	/color:default
+nightly	/color:default
+
+************ COMPGEN `prog @` ************
+__argc_value=file	/color:default
+
+************ COMPGEN `prog +s` ************
+stable	/color:default
+
+

--- a/tests/snapshots/integration__export__case1.snap
+++ b/tests/snapshots/integration__export__case1.snap
@@ -7,9 +7,12 @@ expression: output
   "name": null,
   "author": null,
   "version": null,
-  "metadata": {
-    "combine-shorts": ""
-  },
+  "metadata": [
+    [
+      "combine-shorts",
+      ""
+    ]
+  ],
   "options": [],
   "positionals": [],
   "aliases": [],
@@ -19,7 +22,7 @@ expression: output
       "name": "cmda",
       "author": null,
       "version": null,
-      "metadata": {},
+      "metadata": [],
       "options": [
         {
           "name": "a",
@@ -268,7 +271,7 @@ expression: output
       "name": "cmdb",
       "author": null,
       "version": null,
-      "metadata": {},
+      "metadata": [],
       "options": [
         {
           "name": "oa",
@@ -367,7 +370,7 @@ expression: output
       "name": "cmdc",
       "author": null,
       "version": null,
-      "metadata": {},
+      "metadata": [],
       "options": [
         {
           "name": "oe",
@@ -425,7 +428,7 @@ expression: output
       "name": "cmdd",
       "author": null,
       "version": null,
-      "metadata": {},
+      "metadata": [],
       "options": [
         {
           "name": "oa",
@@ -451,7 +454,7 @@ expression: output
       "name": "cmde",
       "author": null,
       "version": null,
-      "metadata": {},
+      "metadata": [],
       "options": [
         {
           "name": "oa",

--- a/tests/snapshots/integration__spec__symbol.snap
+++ b/tests/snapshots/integration__spec__symbol.snap
@@ -1,0 +1,14 @@
+---
+source: tests/spec.rs
+expression: data
+---
+************ RUN ************
+prog +nightly
+
+OUTPUT
+argc_toolchain=nightly
+argc__args=( prog +nightly )
+argc__cmd_arg_index=0
+argc__positionals=(  )
+
+

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -305,3 +305,12 @@ cmdb() {
         ]
     );
 }
+
+#[test]
+fn symbol() {
+    let script = r###"
+# @meta symbol +toolchain
+# @option --oa
+"###;
+    snapshot_multi!(script, [vec!["prog", "+nightly"]]);
+}


### PR DESCRIPTION
Symbol parameters are specialized, optional positional parameters  starts with a speical charater (Typically  "@" or "+") such as `cargo +toolchain` or `ar @<file>` 

Simulate cargo toolchain symbol parameter
```
# @meta symbol +toolchain[`_choice_toolchain`]
```
Simulate ar file symbol parameter
```
# @meta symbol @file
```