### PR TITLE
feat: support option starts with `+`

### DIFF
--- a/examples/options.sh
+++ b/examples/options.sh
@@ -1,5 +1,4 @@
-# @cmd
-# @describe    All kind of options
+# @cmd All kind of options
 # @option    --oa                   
 # @option -b --ob                   short
 # @option -c                        short only
@@ -23,8 +22,7 @@ options() {
     :;
 }
 
-# @cmd
-# @describe   All kind of flags
+# @cmd All kind of flags
 # @flag     --fa 
 # @flag  -b --fb         short
 # @flag  -c              short only
@@ -34,8 +32,7 @@ flags() {
     :;
 }
 
-# @cmd
-# @describe  Flags or options with single dash
+# @cmd Flags or options with single dash
 # @flag    -fa
 # @flag -b -fb
 # @flag    -fd*
@@ -49,8 +46,7 @@ flags() {
 }
 
 
-# @cmd
-# @describe    All kind of options
+# @cmd All kind of options
 # @option     +oa                   
 # @option +b  +ob                   short
 # @option +c                        short only
@@ -75,8 +71,7 @@ plus_options() {
 }
 
 
-# @cmd
-# @describe   All kind of flags
+# @cmd All kind of flags
 # @flag      +fa 
 # @flag  +b  +fb         short
 # @flag  +c              short only
@@ -86,8 +81,7 @@ plus_flags() {
     :;
 }
 
-# @cmd
-# @describe  Flags or options with single dash
+# @cmd Flags or options with single dash
 # @flag    +fa
 # @flag +b +fb
 # @flag    +fd*
@@ -97,6 +91,13 @@ plus_flags() {
 # @option  +oca[a|b]
 # @option  +ofa[`_choice_fn`]
 plus_1dash() {
+    :;
+}
+
+
+# @cmd Mixed `-` and `+` options
+# @option +b --ob
+mix_options() {
     :;
 }
 

--- a/examples/options.sh
+++ b/examples/options.sh
@@ -48,6 +48,58 @@ flags() {
     :;
 }
 
+
+# @cmd
+# @describe    All kind of options
+# @option     +oa                   
+# @option +b  +ob                   short
+# @option +c                        short only
+# @option     +oc!                  required
+# @option     +od*                  multi-occurs
+# @option     +oe+                  required + multi-occurs
+# @option     +ona <PATH>           value notation
+# @option     +onb <CMD> <FILE>     two-args value notations
+# @option     +onc <CMD> <FILE+>    unlimited-args value notations
+# @option     +oda=a                default
+# @option     +odb=`_default_fn`    default from fn
+# @option     +oca[a|b]             choice
+# @option     +ocb[=a|b]            choice + default
+# @option     +occ*[a|b]            multi-occurs + choice
+# @option     +ocd+[a|b]            required + multi-occurs + choice
+# @option     +ofa[`_choice_fn`]    choice from fn
+# @option     +ofb[?`_choice_fn`]   choice from fn + no validation
+# @option     +ofc*[`_choice_fn`]   multi-occurs + choice from fn
+# @option     +oxa~                 capture all remaining args
+plus_options() {
+    :;
+}
+
+
+# @cmd
+# @describe   All kind of flags
+# @flag      +fa 
+# @flag  +b  +fb         short
+# @flag  +c              short only
+# @flag      +fd*        multi-occurs
+# @flag  +e  +fe*        short + multi-occurs
+plus_flags() {
+    :;
+}
+
+# @cmd
+# @describe  Flags or options with single dash
+# @flag    +fa
+# @flag +b +fb
+# @flag    +fd*
+# @option  +oa
+# @option  +od*
+# @option  +ona <PATH>
+# @option  +oca[a|b]
+# @option  +ofa[`_choice_fn`]
+plus_1dash() {
+    :;
+}
+
 _default_fn() {
     whoami
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -471,7 +471,7 @@ impl Command {
     pub(crate) fn find_flag_option(&self, name: &str) -> Option<&FlagOptionParam> {
         self.flag_option_params
             .iter()
-            .find(|v| v.name() == name || v.is_match(name))
+            .find(|v| v.var_name() == name || v.is_match(name))
     }
 
     pub(crate) fn find_prefixed_option(&self, name: &str) -> Option<(&FlagOptionParam, String)> {
@@ -487,14 +487,14 @@ impl Command {
 
     pub(crate) fn match_version_short_name(&self) -> bool {
         match self.find_flag_option("-V") {
-            Some(param) => param.name() == "version",
+            Some(param) => param.var_name() == "version",
             None => true,
         }
     }
 
     pub(crate) fn match_help_short_name(&self) -> bool {
         match self.find_flag_option("-h") {
-            Some(param) => param.name() == "help",
+            Some(param) => param.var_name() == "help",
             None => true,
         }
     }
@@ -546,7 +546,7 @@ impl Command {
         for subcmd in self.subcommands.iter_mut() {
             let mut inherited_flag_options = vec![];
             for flag_option in &self.flag_option_params {
-                if subcmd.find_flag_option(flag_option.name()).is_none() {
+                if subcmd.find_flag_option(flag_option.var_name()).is_none() {
                     let mut flag_option = flag_option.clone();
                     flag_option.inherit = true;
                     inherited_flag_options.push(flag_option);

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -271,6 +271,14 @@ impl Command {
         self.metadata.iter().any(|(k, _, _)| k == key)
     }
 
+    pub(crate) fn flag_option_signs(&self) -> &str {
+        if self.flag_option_params.iter().any(|v| v.sign == '+') {
+            "+-"
+        } else {
+            "-"
+        }
+    }
+
     pub(crate) fn render_help(&self, cmd_paths: &[&str], term_width: Option<usize>) -> String {
         let mut output = vec![];
         if self.version.is_some() {

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -361,10 +361,10 @@ impl Command {
         }
         let mut list = vec![];
         let mut any_describe = false;
-        let mut single_hyphen = false;
+        let mut single = false;
         for param in self.flag_option_params.iter() {
-            if param.single_hyphen {
-                single_hyphen = true;
+            if param.single {
+                single = true;
             }
             let value = param.render_body();
             let describe = param.render_describe();
@@ -373,8 +373,8 @@ impl Command {
             }
             list.push((value, describe));
         }
-        self.add_help_flag(&mut list, single_hyphen, any_describe);
-        self.add_version_flag(&mut list, single_hyphen, any_describe);
+        self.add_help_flag(&mut list, single, any_describe);
+        self.add_version_flag(&mut list, single, any_describe);
         output.push("OPTIONS:".to_string());
         let value_size = list.iter().map(|v| v.0.len()).max().unwrap_or_default() + 2;
         for (value, describe) in list {
@@ -593,16 +593,11 @@ impl Command {
         self.subcommands.last_mut().unwrap()
     }
 
-    fn add_help_flag(
-        &self,
-        list: &mut Vec<(String, String)>,
-        single_hyphen: bool,
-        any_describe: bool,
-    ) {
+    fn add_help_flag(&self, list: &mut Vec<(String, String)>, single: bool, any_describe: bool) {
         if self.find_flag_option("help").is_some() {
             return;
         }
-        let hyphens = if single_hyphen { " -" } else { "--" };
+        let hyphens = if single { " -" } else { "--" };
         list.push((
             if self.match_help_short_name() {
                 format!("-h, {}help", hyphens)
@@ -617,19 +612,14 @@ impl Command {
         ));
     }
 
-    fn add_version_flag(
-        &self,
-        list: &mut Vec<(String, String)>,
-        single_hyphen: bool,
-        any_describe: bool,
-    ) {
+    fn add_version_flag(&self, list: &mut Vec<(String, String)>, single: bool, any_describe: bool) {
         if self.version.is_none() {
             return;
         }
         if self.find_flag_option("version").is_some() {
             return;
         }
-        let hyphens = if single_hyphen { " -" } else { "--" };
+        let hyphens = if single { " -" } else { "--" };
         list.push((
             if self.match_version_short_name() {
                 format!("-V, {}version", hyphens)

--- a/src/command/names_checker.rs
+++ b/src/command/names_checker.rs
@@ -17,7 +17,7 @@ impl NamesChecker {
         pos: Position,
     ) -> Result<()> {
         let tag_name = param.tag_name();
-        let names = param.list_names();
+        let names = param.list_option_names();
         for name in names.iter() {
             if let Some((exist_pos, _)) = self.flag_options.get(name) {
                 bail!("{}", Self::conflict_error(tag_name, pos, name, *exist_pos));
@@ -33,7 +33,7 @@ impl NamesChecker {
         param: &PositionalParam,
         pos: Position,
     ) -> Result<()> {
-        let name = param.name();
+        let name = param.var_name();
         if let Some(exist_pos) = self.positionals.get(name) {
             bail!(
                 "{}",

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -159,7 +159,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                             &mut arg_comp,
                             &mut split_last_arg_at,
                             combine_shorts,
-                            signs,
+                            &signs,
                         );
                         last_flag_option = Some(param.var_name());
                     } else if let Some((param, prefix)) = cmd.find_prefixed_option(arg) {
@@ -227,7 +227,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                                 &mut arg_comp,
                                 &mut split_last_arg_at,
                                 combine_shorts,
-                                signs,
+                                &signs,
                             );
                             last_flag_option = Some(param.var_name());
                         }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -126,11 +126,11 @@ impl<'a, 'b> Matcher<'a, 'b> {
                         if let Some(param) = cmd.find_flag_option(k) {
                             add_param_choice_fn(&mut choice_fns, param);
                             if is_last_arg {
-                                arg_comp = ArgComp::OptionValue(param.name().to_string(), 0);
+                                arg_comp = ArgComp::OptionValue(param.var_name().to_string(), 0);
                                 split_last_arg_at = Some(k.len() + 1);
                             }
-                            flag_option_args[cmd_level].push((k, vec![v], Some(param.name())));
-                            last_flag_option = Some(param.name());
+                            flag_option_args[cmd_level].push((k, vec![v], Some(param.var_name())));
+                            last_flag_option = Some(param.var_name());
                         } else if let Some((param, prefix)) = cmd.find_prefixed_option(arg) {
                             add_param_choice_fn(&mut choice_fns, param);
                             match_prefix_option(
@@ -142,7 +142,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                                 &mut split_last_arg_at,
                                 &prefix,
                             );
-                            last_flag_option = Some(param.name());
+                            last_flag_option = Some(param.var_name());
                         } else {
                             flag_option_args[cmd_level].push((k, vec![v], None));
                         }
@@ -157,7 +157,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                             &mut split_last_arg_at,
                             combine_shorts,
                         );
-                        last_flag_option = Some(param.name());
+                        last_flag_option = Some(param.var_name());
                     } else if let Some((param, prefix)) = cmd.find_prefixed_option(arg) {
                         add_param_choice_fn(&mut choice_fns, param);
                         match_prefix_option(
@@ -169,7 +169,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                             &mut split_last_arg_at,
                             &prefix,
                         );
-                        last_flag_option = Some(param.name());
+                        last_flag_option = Some(param.var_name());
                     } else if let Some(subcmd) = find_subcommand(cmd, arg, &positional_args)
                         .and_then(|v| {
                             if is_last_arg && compgen {
@@ -224,7 +224,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                                 &mut split_last_arg_at,
                                 combine_shorts,
                             );
-                            last_flag_option = Some(param.name());
+                            last_flag_option = Some(param.var_name());
                         }
                     } else {
                         flag_option_args[cmd_level].push((arg, vec![], None));
@@ -412,7 +412,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                 if let Some(param) = last_cmd
                     .flag_option_params
                     .iter()
-                    .find(|v| v.name() == name)
+                    .find(|v| v.var_name() == name)
                 {
                     comp_flag_option(param, *index)
                 } else {
@@ -464,7 +464,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                 let values: Vec<&[&str]> = args
                     .iter()
                     .filter_map(|(_, value, name)| {
-                        if let Some(true) = name.map(|v| param.name() == v) {
+                        if let Some(true) = name.map(|v| param.var_name() == v) {
                             Some(value.as_slice())
                         } else {
                             None
@@ -598,7 +598,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                 .flag_option_params
                 .iter()
                 .filter(|v| v.required())
-                .map(|v| v.name())
+                .map(|v| v.var_name())
                 .collect();
             for (i, (key, _, name)) in args.iter().enumerate() {
                 match *name {
@@ -617,7 +617,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                 missing_params.extend(missing_flag_options)
             }
             for (name, indexes) in flag_option_map {
-                if let Some(param) = cmd.flag_option_params.iter().find(|v| v.name() == name) {
+                if let Some(param) = cmd.flag_option_params.iter().find(|v| v.var_name() == name) {
                     let values_list: Vec<&[&str]> =
                         indexes.iter().map(|v| args[*v].1.as_slice()).collect();
                     if !param.multi_occurs() && values_list.len() > 1 {
@@ -866,7 +866,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
             .collect();
         let last = self.args.last().map(|v| v.as_str()).unwrap_or_default();
         for param in cmd.flag_option_params.iter() {
-            let mut exist = args.contains(param.name());
+            let mut exist = args.contains(param.var_name());
             if !last.is_empty() && param.is_match(last) {
                 exist = false;
             }
@@ -877,7 +877,7 @@ impl<'a, 'b> Matcher<'a, 'b> {
                 } else {
                     CompColor::of_option()
                 };
-                for v in param.list_names() {
+                for v in param.list_option_names() {
                     output.push((v, describe.to_string(), param.prefixed().is_some(), kind))
                 }
             }
@@ -966,7 +966,7 @@ fn match_combine_shorts<'a, 'b>(
             }
         }
         if let Some(param) = current_cmd.find_flag_option(&name) {
-            output.push((arg, vec![], Some(param.name())))
+            output.push((arg, vec![], Some(param.var_name())))
         } else {
             return None;
         }
@@ -989,10 +989,12 @@ fn match_flag_option<'a, 'b>(
         let arg = &args[*arg_index];
         *arg_index += value_args.len();
         if !value_args.is_empty() {
-            *arg_comp =
-                ArgComp::OptionValue(param.name().to_string(), value_args.len().saturating_sub(1));
+            *arg_comp = ArgComp::OptionValue(
+                param.var_name().to_string(),
+                value_args.len().saturating_sub(1),
+            );
         }
-        flag_option_args.push((arg, value_args, Some(param.name())));
+        flag_option_args.push((arg, value_args, Some(param.var_name())));
     } else {
         let mut values_len = param.arg_value_names.len();
         if param.unlimited_args() {
@@ -1006,20 +1008,20 @@ fn match_flag_option<'a, 'b>(
             if *arg_comp != ArgComp::FlagOrOption {
                 if param.is_option() && value_args.len() <= values_len {
                     *arg_comp = ArgComp::OptionValue(
-                        param.name().to_string(),
+                        param.var_name().to_string(),
                         value_args.len().saturating_sub(1),
                     );
                 }
             } else if let Some(prefix) = param.prefixed() {
                 if arg.starts_with(&prefix) {
-                    *arg_comp = ArgComp::OptionValue(param.name().to_string(), 0);
+                    *arg_comp = ArgComp::OptionValue(param.var_name().to_string(), 0);
                     *split_last_arg_at = Some(prefix.len());
                 }
             } else if combine_shorts && param.is_flag() && !(arg.len() > 2 && param.is_match(arg)) {
                 *arg_comp = ArgComp::FlagOrOptionCombine(arg.to_string());
             }
         }
-        flag_option_args.push((arg, value_args, Some(param.name())));
+        flag_option_args.push((arg, value_args, Some(param.var_name())));
     }
 }
 
@@ -1036,10 +1038,10 @@ fn match_prefix_option<'a, 'b>(
     let args_len = args.len();
     let arg = &args[*arg_index];
     if *arg_index == args_len - 1 {
-        *arg_comp = ArgComp::OptionValue(param.name().to_string(), 0);
+        *arg_comp = ArgComp::OptionValue(param.var_name().to_string(), 0);
         *split_last_arg_at = Some(prefix_len);
     }
-    flag_option_args.push((arg, vec![&arg[prefix_len..]], Some(param.name())));
+    flag_option_args.push((arg, vec![&arg[prefix_len..]], Some(param.var_name())));
 }
 
 fn match_command<'a, 'b>(

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -104,6 +104,7 @@ fn plus_sign() {
 # @flag +a
 # @option +fb[abc|def|ijk]
 # @option +c +fc*[`_choice_fn`]
+# @option +d -fd*[`_choice_fn`]
 _choice_fn() {
 	echo -e "abc\ndef\nghi"
 }
@@ -114,6 +115,7 @@ _choice_fn() {
             vec!["prog", "+"],
             vec!["prog", "+fb="],
             vec!["prog", "+fc", ""],
+            vec!["prog", "-fd", ""],
         ]
     );
 }

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -99,6 +99,26 @@ _choice_fn() {
 }
 
 #[test]
+fn plus_sign() {
+    let script = r#"
+# @flag +a
+# @option +fb[abc|def|ijk]
+# @option +c +fc*[`_choice_fn`]
+_choice_fn() {
+	echo -e "abc\ndef\nghi"
+}
+"#;
+    snapshot_compgen!(
+        script,
+        [
+            vec!["prog", "+"],
+            vec!["prog", "+fb="],
+            vec!["prog", "+fc", ""],
+        ]
+    );
+}
+
+#[test]
 fn subcmds() {
     const SCRIPT: &str = r###"
 # @arg file

--- a/tests/snapshots/integration__compgen__plus_sign.snap
+++ b/tests/snapshots/integration__compgen__plus_sign.snap
@@ -7,6 +7,7 @@ expression: data
 +fb	/color:cyan,bold
 +fc	/color:cyan,bold
 +c	/color:cyan,bold
++d	/color:cyan,bold
 
 ************ COMPGEN `prog +fb=` ************
 abc	/color:default
@@ -14,6 +15,11 @@ def	/color:default
 ijk	/color:default
 
 ************ COMPGEN `prog +fc ` ************
+abc	/color:default
+def	/color:default
+ghi	/color:default
+
+************ COMPGEN `prog -fd ` ************
 abc	/color:default
 def	/color:default
 ghi	/color:default

--- a/tests/snapshots/integration__compgen__plus_sign.snap
+++ b/tests/snapshots/integration__compgen__plus_sign.snap
@@ -1,0 +1,21 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog +` ************
++a	/color:cyan
++fb	/color:cyan,bold
++fc	/color:cyan,bold
++c	/color:cyan,bold
+
+************ COMPGEN `prog +fb=` ************
+abc	/color:default
+def	/color:default
+ijk	/color:default
+
+************ COMPGEN `prog +fc ` ************
+abc	/color:default
+def	/color:default
+ghi	/color:default
+
+

--- a/tests/snapshots/integration__spec__plus_sign.snap
+++ b/tests/snapshots/integration__spec__plus_sign.snap
@@ -1,0 +1,16 @@
+---
+source: tests/spec.rs
+expression: data
+---
+************ RUN ************
+prog +a +fb fb +c fc1 +fc fc2
+
+OUTPUT
+argc_plus_a=1
+argc_plus_fb=fb
+argc_plus_fc=( fc1 fc2 )
+argc__args=( prog +a +fb fb +c fc1 +fc fc2 )
+argc__cmd_arg_index=0
+argc__positionals=(  )
+
+

--- a/tests/snapshots/integration__spec__plus_sign.snap
+++ b/tests/snapshots/integration__spec__plus_sign.snap
@@ -13,4 +13,13 @@ argc__args=( prog +a +fb fb +c fc1 +fc fc2 )
 argc__cmd_arg_index=0
 argc__positionals=(  )
 
+************ RUN ************
+prog +d fd1 -fd fd2
+
+OUTPUT
+argc_fd=( fd1 fd2 )
+argc__args=( prog +d fd1 -fd fd2 )
+argc__cmd_arg_index=0
+argc__positionals=(  )
+
 

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -321,9 +321,13 @@ fn plus_sign() {
 # @flag +a
 # @option +fb
 # @option +c +fc*
+# @option +d -fd*
 "###;
     snapshot_multi!(
         script,
-        [vec!["prog", "+a", "+fb", "fb", "+c", "fc1", "+fc", "fc2"]]
+        [
+            vec!["prog", "+a", "+fb", "fb", "+c", "fc1", "+fc", "fc2"],
+            vec!["prog", "+d", "fd1", "-fd", "fd2"],
+        ]
     );
 }

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -314,3 +314,16 @@ fn symbol() {
 "###;
     snapshot_multi!(script, [vec!["prog", "+nightly"]]);
 }
+
+#[test]
+fn plus_sign() {
+    let script = r###"
+# @flag +a
+# @option +fb
+# @option +c +fc*
+"###;
+    snapshot_multi!(
+        script,
+        [vec!["prog", "+a", "+fb", "fb", "+c", "fc1", "+fc", "fc2"]]
+    );
+}


### PR DESCRIPTION
```
# @option     +oa                   
# @option +b  +ob                   short
# @option +c                        short only
# @option     +oc!                  required
# @option     +od*                  multi-occurs
# @option     +oe+                  required + multi-occurs
# @option     +ona <PATH>           value notation
# @option     +onb <CMD> <FILE>     two-args value notations
# @option     +onc <CMD> <FILE+>    unlimited-args value notations
# @option     +oda=a                default
# @option     +odb=`_default_fn`    default from fn
# @option     +oca[a|b]             choice
# @option     +ocb[=a|b]            choice + default
# @option     +occ*[a|b]            multi-occurs + choice
# @option     +ocd+[a|b]            required + multi-occurs + choice
# @option     +ofa[`_choice_fn`]    choice from fn
# @option     +ofb[?`_choice_fn`]   choice from fn + no validation
# @option     +ofc*[`_choice_fn`]   multi-occurs + choice from fn
# @option     +oxa~                 capture all remaining args
```

Mix `-`/`+` option
```
# @option +b  -ob
# @option +c --oc
# @option -d  +od
```