### PR TITLE
feat: support allow-empty option

### DIFF
--- a/tests/snapshots/integration__spec__zero_or_one.snap
+++ b/tests/snapshots/integration__spec__zero_or_one.snap
@@ -1,0 +1,23 @@
+---
+source: tests/spec.rs
+expression: data
+---
+************ RUN ************
+prog --oa
+
+OUTPUT
+argc_oa=1
+argc__args=( prog --oa )
+argc__cmd_arg_index=0
+argc__positionals=(  )
+
+************ RUN ************
+prog --oa v1
+
+OUTPUT
+argc_oa=v1
+argc__args=( prog --oa v1 )
+argc__cmd_arg_index=0
+argc__positionals=(  )
+
+

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -331,3 +331,11 @@ fn plus_sign() {
         ]
     );
 }
+
+#[test]
+fn zero_or_one() {
+    let script = r###"
+# @option --oa <VALUE?>
+"###;
+    snapshot_multi!(script, [vec!["prog", "--oa"], vec!["prog", "--oa", "v1"]]);
+}


### PR DESCRIPTION
A allow-empty option is an option that can accept no value and work like a flag.

```
# @option --foo <VALUE?>
```
```
prog --foo         # This is valid
prog --foo value
```