### PR TITLE
refactor: avoid regenerate argc-completer if it already exists

### DIFF
--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -5,7 +5,7 @@ set -e
 # @cmd Test the project
 # @alias t
 test() {
-    cargo test $@
+    cargo test "$@"
 }
 
 # @cmd Check the project
@@ -28,42 +28,13 @@ fix() {
 # @arg cmds* any other scripts based on argc
 setup-shell() {
     case $argc_shell in
-     bash)
-        cat <<EOF
-source <(argc --argc-completions bash ${argc_cmds[@]})
-EOF
-     ;;
-     elvish)
-        cat <<EOF
-eval (argc --argc-completions elvish ${argc_cmds[@]} | slurp)
-EOF
-     ;;
-     fish)
-        cat <<EOF
-argc --argc-completions fish ${argc_cmds[@]} | source
-EOF
-     ;;
-     nushell)
-        cat <<EOF
-argc --argc-completions nushell ${argc_cmds[@]} | save -f /tmp/argc.nu
-source /tmp/argc.nu
-EOF
-     ;;
-     powershell)
-        cat <<EOF
-argc --argc-completions powershell ${argc_cmds[@]} | Out-String | Invoke-Expression
-EOF
-     ;;
-     xonsh)
-        cat <<EOF
-exec(\$(argc --argc-completions xonsh ${argc_cmds[@]}))
-EOF
-     ;;
-     zsh)
-        cat <<EOF
-source <(argc --argc-completions zsh ${argc_cmds[@]})
-EOF
-     ;;
+     bash) echo "source <(argc --argc-completions bash ${argc_cmds[@]})" ;;
+     elvish) echo "eval (argc --argc-completions elvish ${argc_cmds[@]} | slurp)" ;;
+     fish) echo "argc --argc-completions fish ${argc_cmds[@]} | source" ;;
+     nushell) echo "argc --argc-completions nushell ${argc_cmds[@]} | save -f /tmp/argc.nu"$'\n'"source /tmp/argc.nu" ;;
+     powershell) echo "argc --argc-completions powershell ${argc_cmds[@]} | Out-String | Invoke-Expression" ;;
+     xonsh) echo "exec(\$(argc --argc-completions xonsh ${argc_cmds[@]}))" ;;
+     zsh) echo "source <(argc --argc-completions zsh ${argc_cmds[@]})" ;;
     esac
 }
 

--- a/src/bin/argc/completions/argc.bash
+++ b/src/bin/argc/completions/argc.bash
@@ -1,6 +1,6 @@
 _argc_completer() {
-    local words cword
-    _argc_parse_comp_line
+    local words
+    _argc_completer_parse_line
 
     export COMP_WORDBREAKS
     while IFS=$'\n' read -r line; do
@@ -8,7 +8,7 @@ _argc_completer() {
     done < <(argc --argc-compgen bash "" "${words[@]}" 2>/dev/null)
 }
 
-_argc_parse_comp_line() {
+_argc_completer_parse_line() {
     local line len i char prev_char word unbalance word_index
     word_index=0
     line="${COMP_LINE:0:$COMP_POINT}"
@@ -41,5 +41,4 @@ _argc_parse_comp_line() {
         prev_char="$char"
     done
     words[$word_index]="$word"
-    cword="$word"
 }

--- a/src/bin/argc/completions/argc.nu
+++ b/src/bin/argc/completions/argc.nu
@@ -3,3 +3,17 @@ def _argc_completer [args: list<string>] {
         | split row "\n" | range 0..-2 
         | each { |line| $line | split column "\t" value description } | flatten 
 }
+
+let external_completer = {{|spans| 
+    if (not ($env.ARGC_SCRIPTS | find $spans.0 | is-empty)) {{
+        _argc_completer $spans
+    }} else {{
+        # default completer
+    }}
+}}
+
+$env.config.completions.external = {{
+    enable: true
+    max_results: 100
+    completer: $external_completer
+}}

--- a/src/bin/argc/completions/argc.zsh
+++ b/src/bin/argc/completions/argc.zsh
@@ -1,12 +1,12 @@
 _argc_completer() {
-    local words2 cword
-    _argc_reassemble_words
+    local new_words
+    _argc_completer_reassemble_words
 
     local candidates=() values=() displays=() colors display_value
     while IFS=$'\n' read -r line; do
         if [[ "$line" == "" ]]; then line=$'\0'; fi
         candidates+=( "$line" )
-    done < <(argc --argc-compgen zsh $'\0' $words2 2>/dev/null)
+    done < <(argc --argc-compgen zsh $'\0' $new_words 2>/dev/null)
     for candidate in ${candidates[@]}; do
         IFS=$'\t' read -r value display color_key color <<< "$candidate"
         colors="$colors:=(#b)($color_key)( * -- *)=0=$color=2;37:=(#b)($color_key)()=0=$color=2;37"
@@ -17,13 +17,13 @@ _argc_completer() {
     _describe "" displays values -Q -S '' -o nosort
 }
 
-_argc_reassemble_words() {
-    local i
-    words2=()
+_argc_completer_reassemble_words() {
+    local i cword
+    new_words=()
     for ((i=1; i<=$CURRENT; i++)); do
         cword="$words[$i]"
         if [[ "$cword" == "" ]]; then
-            words2+=( $'\0' )
+            new_words+=( $'\0' )
         else
             if [[ "$cword" == *"\\"* ]]; then
                 local j char next_char cword_len word
@@ -42,7 +42,7 @@ _argc_reassemble_words() {
                 done
                 cword="$word"
             fi
-            words2+=( "$cword" )
+            new_words+=( "$cword" )
         fi
     done
 }

--- a/src/bin/argc/completions/mod.rs
+++ b/src/bin/argc/completions/mod.rs
@@ -18,11 +18,9 @@ const XONSH_SCRIPT: &str = include_str!("argc.xsh");
 
 pub fn generate(shell: Shell, args: &[String]) -> Result<String> {
     let mut cmds = args.to_vec();
-    let shell_completion_name = format!("ARGC_{}_COMPLETION", shell.name().to_uppercase());
-    let shell_completion = std::env::var(&shell_completion_name)
-        .ok()
-        .unwrap_or_default();
-    let append_mode = shell_completion == "1";
+    let completion_shell = format!("ARGC_COMPLETION_{}", shell.name().to_uppercase());
+    let exist_completion = std::env::var(&completion_shell).ok().unwrap_or_default();
+    let append_mode = exist_completion == "1";
     if !append_mode {
         cmds.insert(0, "argc".to_string());
     }
@@ -30,14 +28,14 @@ pub fn generate(shell: Shell, args: &[String]) -> Result<String> {
     let mut cmds_code = String::new();
     match shell {
         Shell::Bash => {
-            share_script = format!("{BASH_SCRIPT}\nexport {shell_completion_name}=1\n");
+            share_script = format!("{BASH_SCRIPT}\nexport {completion_shell}=1\n");
             cmds_code = format!(
                 "complete -F _argc_completer -o nospace -o nosort {}",
                 cmds.join(" ")
             );
         }
         Shell::Elvish => {
-            share_script = format!("{ELVISH_SCRIPT}\nset E:{shell_completion_name} = 1\n");
+            share_script = format!("{ELVISH_SCRIPT}\nset E:{completion_shell} = 1\n");
             cmds_code = cmds
                 .iter()
                 .map(|v| {
@@ -51,7 +49,7 @@ pub fn generate(shell: Shell, args: &[String]) -> Result<String> {
                 .join("\n");
         }
         Shell::Fish => {
-            share_script = format!("{FISH_SCRIPT}\nset -gx {shell_completion_name} 1\n");
+            share_script = format!("{FISH_SCRIPT}\nset -gx {completion_shell} 1\n");
             cmds_code = cmds
                 .iter()
                 .map(|v| format!("complete -x -k -c {v} -a \"(_argc_completer)\""))
@@ -60,7 +58,7 @@ pub fn generate(shell: Shell, args: &[String]) -> Result<String> {
         }
         Shell::Generic => {}
         Shell::Nushell => {
-            share_script = format!("{NUSHELL_SCRIPT}\n$env.{shell_completion_name} = 1\n");
+            share_script = format!("{NUSHELL_SCRIPT}\n$env.{completion_shell} = 1\n");
             if append_mode {
                 cmds_code = format!("$env.ARGC_SCRIPTS = $env.ARGC_SCRIPTS ++ {cmds:?}");
             } else {
@@ -68,11 +66,11 @@ pub fn generate(shell: Shell, args: &[String]) -> Result<String> {
             }
         }
         Shell::Powershell => {
-            share_script = format!("{POWERSHELL_SCRIPT}\n$env:{shell_completion_name} = 1\n");
+            share_script = format!("{POWERSHELL_SCRIPT}\n$env:{completion_shell} = 1\n");
             cmds_code = cmds.iter().map(|v| format!("Register-ArgumentCompleter -Native -ScriptBlock $_argc_completer -CommandName {v}")).collect::<Vec<String>>().join("\n");
         }
         Shell::Xonsh => {
-            share_script = format!("{XONSH_SCRIPT}\n${shell_completion_name} = 1\n");
+            share_script = format!("{XONSH_SCRIPT}\n${completion_shell} = 1\n");
             if append_mode {
                 cmds_code = format!("ARGC_SCRIPTS.extend({cmds:?})");
             } else {
@@ -80,7 +78,7 @@ pub fn generate(shell: Shell, args: &[String]) -> Result<String> {
             }
         }
         Shell::Zsh => {
-            share_script = format!("{ZSH_SCRIPT}\nexport {shell_completion_name}=1\n");
+            share_script = format!("{ZSH_SCRIPT}\nexport {completion_shell}=1\n");
             cmds_code = format!("compdef _argc_completer {}", cmds.join(" "));
         }
     };

--- a/src/bin/argc/completions/mod.rs
+++ b/src/bin/argc/completions/mod.rs
@@ -17,82 +17,81 @@ const NUSHELL_SCRIPT: &str = include_str!("argc.nu");
 const XONSH_SCRIPT: &str = include_str!("argc.xsh");
 
 pub fn generate(shell: Shell, args: &[String]) -> Result<String> {
-    let mut cmds = vec!["argc"];
-    cmds.extend(args.iter().map(|v| v.as_str()));
-    let output = match shell {
+    let mut cmds = args.to_vec();
+    let shell_completion_name = format!("ARGC_{}_COMPLETION", shell.name().to_uppercase());
+    let shell_completion = std::env::var(&shell_completion_name)
+        .ok()
+        .unwrap_or_default();
+    let append_mode = shell_completion == "1";
+    if !append_mode {
+        cmds.insert(0, "argc".to_string());
+    }
+    let mut share_script = String::new();
+    let mut cmds_code = String::new();
+    match shell {
         Shell::Bash => {
-            let code = format!(
+            share_script = format!("{BASH_SCRIPT}\nexport {shell_completion_name}=1\n");
+            cmds_code = format!(
                 "complete -F _argc_completer -o nospace -o nosort {}",
                 cmds.join(" ")
             );
-            format!("{BASH_SCRIPT}\n{code}\n",)
         }
         Shell::Elvish => {
-            let lines: Vec<String> = cmds
+            share_script = format!("{ELVISH_SCRIPT}\nset E:{shell_completion_name} = 1\n");
+            cmds_code = cmds
                 .iter()
-                .map(|v| format!(r#"set edit:completion:arg-completer[{v}] = $argc-completer~"#))
-                .collect();
-            let code = lines.join("\n");
-            format!("{ELVISH_SCRIPT}\n{code}\n",)
+                .map(|v| {
+                    if append_mode {
+                        format!("set edit:completion:arg-completer[{v}] = $edit:completion:arg-completer[argc]")
+                    } else {
+                        format!("set edit:completion:arg-completer[{v}] = $argc-completer~")
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join("\n");
         }
         Shell::Fish => {
-            let lines: Vec<String> = cmds
+            share_script = format!("{FISH_SCRIPT}\nset -gx {shell_completion_name} 1\n");
+            cmds_code = cmds
                 .iter()
-                .map(|v| format!(r###"complete -x -k -c {v} -a "(_argc_completer)""###))
-                .collect();
-            let code = lines.join("\n");
-            format!("{FISH_SCRIPT}\n{code}\n",)
+                .map(|v| format!("complete -x -k -c {v} -a \"(_argc_completer)\""))
+                .collect::<Vec<String>>()
+                .join("\n");
         }
-        Shell::Generic => String::new(),
+        Shell::Generic => {}
         Shell::Nushell => {
-            let cmds = format!("{cmds:?}");
-            format!(
-                r###"{NUSHELL_SCRIPT}
-if ('ARGC_SCRIPTS' in $env) {{
-    $env.ARGC_SCRIPTS = ($env.ARGC_SCRIPTS | append {cmds} | uniq)
-}} else {{
-    $env.ARGC_SCRIPTS = {cmds}
-}}
-
-let external_completer = {{|spans| 
-    if (not ($env.ARGC_SCRIPTS | find $spans.0 | is-empty)) {{
-        _argc_completer $spans
-    }} else {{
-        # default completer
-    }}
-}}
-
-$env.config.completions.external = {{
-    enable: true
-    max_results: 100
-    completer: $external_completer
-}}
-"###,
-            )
+            share_script = format!("{NUSHELL_SCRIPT}\n$env.{shell_completion_name} = 1\n");
+            if append_mode {
+                cmds_code = format!("$env.ARGC_SCRIPTS = $env.ARGC_SCRIPTS ++ {cmds:?}");
+            } else {
+                cmds_code = format!("$env.ARGC_SCRIPTS = {cmds:?}");
+            }
         }
         Shell::Powershell => {
-            let lines: Vec<String> = cmds.iter().map(|v| format!("Register-ArgumentCompleter -Native -ScriptBlock $_argc_completer -CommandName {v} ")).collect();
-            let code = lines.join("\n");
-            format!("{POWERSHELL_SCRIPT}\n{code}\n",)
+            share_script = format!("{POWERSHELL_SCRIPT}\n$env:{shell_completion_name} = 1\n");
+            cmds_code = cmds.iter().map(|v| format!("Register-ArgumentCompleter -Native -ScriptBlock $_argc_completer -CommandName {v}")).collect::<Vec<String>>().join("\n");
         }
         Shell::Xonsh => {
-            let cmds = format!("{cmds:?}");
-            format!(
-                r###"{XONSH_SCRIPT}
-if 'ARGC_SCRIPTS' in globals():
-    ARGC_SCRIPTS.extend(item for item in {cmds} 
-        if item not in ARGC_SCRIPTS)
-else:
-    ARGC_SCRIPTS = {cmds} 
-"###,
-            )
+            share_script = format!("{XONSH_SCRIPT}\n${shell_completion_name} = 1\n");
+            if append_mode {
+                cmds_code = format!("ARGC_SCRIPTS.extend({cmds:?})");
+            } else {
+                cmds_code = format!("ARGC_SCRIPTS = {cmds:?}");
+            }
         }
         Shell::Zsh => {
-            let code = format!("compdef _argc_completer {}", cmds.join(" "));
-            format!("{ZSH_SCRIPT}\n{code}\n",)
+            share_script = format!("{ZSH_SCRIPT}\nexport {shell_completion_name}=1\n");
+            cmds_code = format!("compdef _argc_completer {}", cmds.join(" "));
         }
     };
-    Ok(output)
+    if append_mode {
+        if cmds.is_empty() {
+            return Ok(String::new());
+        }
+        Ok(cmds_code.to_string())
+    } else {
+        Ok(format!("{share_script}{cmds_code}"))
+    }
 }
 
 #[test]

--- a/src/bin/argc/main.rs
+++ b/src/bin/argc/main.rs
@@ -91,7 +91,9 @@ fn run() -> Result<i32> {
                     None => bail!("Usage: argc --argc-completions <SHELL> [CMDS]..."),
                 };
                 let script = crate::completions::generate(shell, &args[3..])?;
-                println!("{}", script);
+                if !script.is_empty() {
+                    println!("{}", script);
+                }
             }
             "--argc-parallel" => {
                 if args.len() <= 3 {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::{HashMap, HashSet},
     env,
-    path::MAIN_SEPARATOR,
 };
 
 use crate::{
@@ -687,7 +686,6 @@ impl<'a, 'b> Matcher<'a, 'b> {
         let fns: Vec<&str> = self.choice_fns.iter().copied().collect();
         let mut envs = HashMap::new();
         envs.insert("ARGC_OS".into(), env::consts::OS.to_string());
-        envs.insert("ARGC_PATH_SEP".into(), MAIN_SEPARATOR.into());
         let outputs = run_param_fns(script_path, &fns, self.args, envs)?;
         for (i, output) in outputs.into_iter().enumerate() {
             let choices = output


### PR DESCRIPTION
First time generate full completion scripts

Run `argc --argc-completions bash mycmd1`
```
_argc_completer() {
    local words
    _argc_completer_parse_line

    export COMP_WORDBREAKS
    while IFS=$'\n' read -r line; do
        COMPREPLY+=( "$line" )
    done < <(argc --argc-compgen bash "" "${words[@]}" 2>/dev/null)
}

...

export ARGC_COMPLETION_BASH=1
complete -F _argc_completer -o nospace -o nosort argc mycmd1
```

Next time, when argc detects that ARGC_COMPLETION_BASH is set to 1, it will only generate snippets to just register the completer
Run `argc --argc-completions bash mycmd2`
```
complete -F _argc_completer -o nospace -o nosort mycmd2
```

This strategy is applied to all shells.