### PR TITLE
feat: auto-search completion script in ARGC_COMPLETIONS_PATH

### DIFF
--- a/src/bin/argc/main.rs
+++ b/src/bin/argc/main.rs
@@ -160,11 +160,13 @@ fn run_compgen(mut args: Vec<String>) -> Option<()> {
     let shell: Shell = args.get(2).and_then(|v| v.parse().ok())?;
     if args[3].is_empty() {
         if args[4] == "argc" {
-            if let Some((_, script_file_)) = get_script_path(true) {
-                args[3] = script_file_.to_string_lossy().to_string();
+            if let Some((_, script_file)) = get_script_path(true) {
+                args[3] = script_file.to_string_lossy().to_string();
             }
-        } else if let Ok(script_file_) = which(&args[4]) {
-            args[3] = script_file_.to_string_lossy().to_string();
+        } else if let Some(script_file) = search_completion_script(&mut args) {
+            args[3] = script_file.to_string_lossy().to_string();
+        } else if let Ok(script_file) = which(&args[4]) {
+            args[3] = script_file.to_string_lossy().to_string();
         } else {
             return None;
         }


### PR DESCRIPTION
When run `argc --argc-compgen bash '' mycmd ''`  without setting the argcfile(the fourth argument),  argc will automatically search for the script file at `$ARGC_COMPLETIONS_PATH`.

This can reduce the difficulty of using argc as a completion engine.

Users now can create a `my-completions-dir` directory and then place argc-based completion scripts within that directory.
Use the following code to autoload the completion scripts in the directory.
```
export ARGC_COMPLETIONS_PATH=my-completions-dir
eval <(ls -1 my-completions-dir | sed -n 's/\.sh$//p' | xargs argc --argc-completions bash)
```