### PR TITLE
feat: support hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,33 @@
+# Hooks
+
+Argc supports two kinds of hooks:
+
+- `_argc_before`: call before performing any operation
+- `_argc_before`: call after running the command function
+
+
+```sh
+# @flag --foo
+# @option --bar
+
+_argc_before() {
+  echo before
+}
+
+_argc_after() {
+  echo after
+}
+
+main() {
+  echo main
+}
+
+eval "$(argc --argc-eval "$0" "$@")"
+```
+
+```
+$ prog
+before
+after
+main
+```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -5,6 +5,7 @@ Argc supports two kinds of hooks:
 - `_argc_before`: call before performing any operation
 - `_argc_before`: call after running the command function
 
+## Example
 
 ```sh
 # @flag --foo
@@ -28,6 +29,6 @@ eval "$(argc --argc-eval "$0" "$@")"
 ```
 $ prog
 before
-after
 main
+after
 ```

--- a/examples/hooks.sh
+++ b/examples/hooks.sh
@@ -1,0 +1,20 @@
+#/usr/bin/env node
+
+set -e
+
+# @flag --foo
+# @option --bar
+
+_argc_before() {
+  echo before
+}
+
+_argc_after() {
+  echo after
+}
+
+main() {
+  echo main
+}
+
+eval "$(argc --argc-eval "$0" "$@")"

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -4,7 +4,7 @@ mod root_data;
 use self::names_checker::NamesChecker;
 use self::root_data::RootData;
 
-use crate::argc_value::ArgcValue;
+use crate::argc_value::{ArgcValue, AFTER_HOOK, BEFORE_HOOK};
 use crate::matcher::Matcher;
 use crate::param::{FlagOptionParam, PositionalParam};
 use crate::parser::{parse, parse_symbol, Event, EventData, EventScope, Position};
@@ -535,6 +535,11 @@ impl Command {
                 None
             }
         }
+    }
+
+    pub(crate) fn exist_hook_fns(&self) -> (bool, bool) {
+        let fns = &self.root.borrow().fns;
+        (fns.contains_key(BEFORE_HOOK), fns.contains_key(AFTER_HOOK))
     }
 
     pub(crate) fn delegated(&self) -> bool {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -330,6 +330,8 @@ impl<'a, 'b> Matcher<'a, 'b> {
                 self.positional_args.iter().map(|v| v.to_string()).collect(),
             ));
         }
+        let (before, after) = cmd.exist_hook_fns();
+        output.push(ArgcValue::HookFns((before, after)));
         if let Some(cmd_fn) = cmd.get_cmd_fn(&cmd_paths) {
             output.push(ArgcValue::CmdFn(cmd_fn));
         }

--- a/tests/hook_fn.rs
+++ b/tests/hook_fn.rs
@@ -1,0 +1,32 @@
+use crate::*;
+
+#[test]
+fn hook_without_subcmd() {
+    let script = r###"
+_argc_before() { :; }
+_argc_after() { :; }
+"###;
+    snapshot!(script, &["prog"]);
+}
+
+#[test]
+fn hook_with_main() {
+    let script = r###"
+_argc_before() { :; }
+_argc_after() { :; }
+main() { :; }
+"###;
+    snapshot!(script, &["prog"]);
+}
+
+#[test]
+fn hook_with_subcmd() {
+    let script = r###"
+_argc_before() { :; }
+_argc_after() { :; }
+
+# @cmd
+cmd() { :; }
+"###;
+    snapshot!(script, &["prog", "cmd"]);
+}

--- a/tests/hook_fn.rs
+++ b/tests/hook_fn.rs
@@ -20,6 +20,15 @@ main() { :; }
 }
 
 #[test]
+fn hook_only_before() {
+    let script = r###"
+_argc_before() { :; }
+main() { :; }
+"###;
+    snapshot!(script, &["prog"]);
+}
+
+#[test]
 fn hook_with_subcmd() {
     let script = r###"
 _argc_before() { :; }

--- a/tests/snapshots/integration__hook_fn__hook_only_before.snap
+++ b/tests/snapshots/integration__hook_fn__hook_only_before.snap
@@ -1,0 +1,15 @@
+---
+source: tests/hook_fn.rs
+expression: data
+---
+RUN
+prog
+
+OUTPUT
+argc__args=( prog )
+argc__cmd_arg_index=0
+argc__fn=main
+argc__positionals=(  )
+_argc_before
+main
+

--- a/tests/snapshots/integration__hook_fn__hook_with_main.snap
+++ b/tests/snapshots/integration__hook_fn__hook_with_main.snap
@@ -1,0 +1,16 @@
+---
+source: tests/hook_fn.rs
+expression: data
+---
+RUN
+prog
+
+OUTPUT
+argc__args=( prog )
+argc__cmd_arg_index=0
+argc__fn=main
+argc__positionals=(  )
+_argc_before
+main
+_argc_after
+

--- a/tests/snapshots/integration__hook_fn__hook_with_subcmd.snap
+++ b/tests/snapshots/integration__hook_fn__hook_with_subcmd.snap
@@ -1,0 +1,16 @@
+---
+source: tests/hook_fn.rs
+expression: data
+---
+RUN
+prog cmd
+
+OUTPUT
+argc__args=( prog cmd )
+argc__cmd_arg_index=1
+argc__fn=cmd
+argc__positionals=(  )
+_argc_before
+cmd
+_argc_after
+

--- a/tests/snapshots/integration__hook_fn__hook_without_subcmd.snap
+++ b/tests/snapshots/integration__hook_fn__hook_without_subcmd.snap
@@ -1,0 +1,13 @@
+---
+source: tests/hook_fn.rs
+expression: data
+---
+RUN
+prog
+
+OUTPUT
+argc__args=( prog )
+argc__cmd_arg_index=0
+argc__positionals=(  )
+_argc_before
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,6 +13,7 @@ mod compgen;
 mod create;
 mod export;
 mod fail;
+mod hook_fn;
 mod main_fn;
 mod misc;
 mod parallel;


### PR DESCRIPTION
Argc supports two kinds of hooks:

- `_argc_before`: call before performing any operation
- `_argc_before`: call after running the command function


```sh
# @flag --foo
# @option --bar

_argc_before() {
  echo before
}

_argc_after() {
  echo after
}

main() {
  echo main
}

eval "$(argc --argc-eval "$0" "$@")"
```

```
$ prog
before
main
after
```
