### PR TITLE
feat: support default subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,14 @@ Add a metadata.
 # @meta key [value]
 ```
 
-| usage                        | description                                                               |
-| ---------------------------- | ------------------------------------------------------------------------- |
-| `@meta dotenv [<path>]`      | Load a `.env` file from a custom path, if persent.                        |
-| `@meta combine-shorts`       | Short flags can be combined, e.g. `prog -xf => prog -x -f `               |
-| `@meta inherit-flag-options` | Subcommands will inherit the flags/options from their parent.             |
-| `@meta no-inherit-env`       | Subcommands will not inherit the environment variables from their parent. |
-| `@meta symbol <def>`         | Define a symbolic parameter, e.g. `+toolchain`, `@argument-file`          |
+| usage                        | scope  | description                                                            |
+| :--------------------------- | ------ | :--------------------------------------------------------------------- |
+| `@meta dotenv [<path>]`      | root   | Load a `.env` file from a custom path, if persent.                     |
+| `@meta default-subcommand`   | subcmd | Set the current subcommand as the default.                             |
+| `@meta inherit-flag-options` | root   | Subcommands will inherit the flags/options from their parent.          |
+| `@meta no-inherit-env`       | root   | Subcommands won't inherit the environment variables from their parent. |
+| `@meta symbol <param>`       | anycmd | Define a symbolic parameter, e.g. `+toolchain`, `@argument-file`.      |
+| `@meta combine-shorts`       | root   | Short flags can be combined, e.g. `prog -xf => prog -x -f `.           |
 
 ### @describe / @version / @author
 

--- a/examples/command-default.sh
+++ b/examples/command-default.sh
@@ -1,0 +1,14 @@
+# describe Sample CLI that uses the default command option
+
+# @cmd Upload a file
+# @meta default-subcommand
+upload() {
+    echo upload "$@"
+}
+
+# @cmd Download a file
+download() {
+    echo download "$@"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"

--- a/examples/command-nested.sh
+++ b/examples/command-nested.sh
@@ -1,4 +1,4 @@
-# @describe docker cli
+# @describe Docker CLI mocking
 
 # @cmd
 builder() { :; }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,6 +13,13 @@ pub const BEFORE_HOOK: &str = "_argc_before";
 pub const AFTER_HOOK: &str = "_argc_after";
 pub const ROOT_NAME: &str = "prog";
 
+pub const META_DOTENV: &str = "dotenv";
+pub const META_DEFAULT_SUBCOMMAND: &str = "default-subcommand";
+pub const META_INHERIT_FLAG_OPTIONS: &str = "inherit-flag-options";
+pub const META_NO_INHERIT_ENV: &str = "no-inherit-env";
+pub const META_SYMBOL: &str = "symbol";
+pub const META_COMBINE_SHORTS: &str = "combine-shorts";
+
 pub fn to_cobol_case(value: &str) -> String {
     Converter::new()
         .set_pattern(Pattern::Uppercase)

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -776,6 +776,25 @@ abc() { :; }
 }
 
 #[test]
+fn default_subcommand() {
+    let script = r###"
+# @cmd
+# @meta default-subcommand
+# @arg val*[`_choice_fn`]
+cmda() { :; }
+
+# @cmd
+cmdb() { :; }
+
+_choice_fn() {
+    echo -e "abc\ndef\nijk"
+}
+"###;
+
+    snapshot_compgen!(script, [vec!["prog", ""], vec!["prog", "abc", ""]]);
+}
+
+#[test]
 fn multi_char() {
     let script = r#"
 # @option --oa*,[`_choice_fn`]

--- a/tests/snapshots/integration__compgen__default_subcommand.snap
+++ b/tests/snapshots/integration__compgen__default_subcommand.snap
@@ -1,0 +1,18 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog ` ************
+cmda	/color:magenta
+cmdb	/color:magenta
+help	/color:magenta
+abc	/color:default
+def	/color:default
+ijk	/color:default
+
+************ COMPGEN `prog abc ` ************
+abc	/color:default
+def	/color:default
+ijk	/color:default
+
+

--- a/tests/snapshots/integration__spec__default_subcommand.snap
+++ b/tests/snapshots/integration__spec__default_subcommand.snap
@@ -1,0 +1,71 @@
+---
+source: tests/spec.rs
+expression: data
+---
+************ RUN ************
+prog -h
+
+# OUTPUT
+command cat >&2 <<-'EOF' 
+USAGE: prog <COMMAND>
+
+COMMANDS:
+  cmda  [default]
+  cmdb
+
+EOF
+exit 0
+
+# RUN_OUTPUT
+USAGE: prog <COMMAND>
+
+COMMANDS:
+  cmda  [default]
+  cmdb
+
+************ RUN ************
+prog v1
+
+# OUTPUT
+argc__args=( prog v1 )
+argc__fn=cmda
+argc__positionals=( v1 )
+cmda v1
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="v1")
+argc__fn=cmda
+argc__positionals=([0]="v1")
+cmda v1
+
+************ RUN ************
+prog cmda v1
+
+# OUTPUT
+argc__args=( prog cmda v1 )
+argc__fn=cmda
+argc__positionals=( v1 )
+cmda v1
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="cmda" [2]="v1")
+argc__fn=cmda
+argc__positionals=([0]="v1")
+cmda v1
+
+************ RUN ************
+prog cmdb v1
+
+# OUTPUT
+argc__args=( prog cmdb v1 )
+argc__fn=cmdb
+argc__positionals=( v1 )
+cmdb v1
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="cmdb" [2]="v1")
+argc__fn=cmdb
+argc__positionals=([0]="v1")
+cmdb v1
+
+

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -339,3 +339,24 @@ fn notation_modifier() {
         ]
     );
 }
+
+#[test]
+fn default_subcommand() {
+    let script = r###"
+# @cmd
+# @meta default-subcommand
+cmda() { :; }
+
+# @cmd
+cmdb() { :; }
+"###;
+    snapshot_multi!(
+        script,
+        [
+            vec!["prog", "-h"],
+            vec!["prog", "v1"],
+            vec!["prog", "cmda", "v1"],
+            vec!["prog", "cmdb", "v1"],
+        ]
+    );
+}


### PR DESCRIPTION
use `@meta default-subcommand`  to set the current subcommand as the default.

```sh
# describe Sample CLI that uses the default command option

# @cmd Upload a file
# @meta default-subcommand
upload() {
    echo upload "$@"
}

# @cmd Download a file
download() {
    echo download "$@"
}

eval "$(argc --argc-eval "$0" "$@")"
```

```
$ bash examples/command-default.sh foo
upload foo
$ bash examples/command-default.sh upload foo
upload foo
```