### PR TITLE
feat: support option whose names ends with `-` and `:`

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -125,10 +125,10 @@ impl Param for FlagOptionParam {
             output.push(short.to_string());
         };
         let mut name_suffix = String::new();
-        if self.prefixed {
+        if self.prefixed || self.data.name.ends_with('-') {
             name_suffix.push('-');
         }
-        if self.assigned {
+        if self.assigned || self.data.name.ends_with(":") {
             name_suffix.push(':');
         }
         output.push(format!(
@@ -156,11 +156,15 @@ impl FlagOptionParam {
         row_notations: &[&str],
     ) -> Self {
         let (mut prefixed, mut assigned) = (false, false);
-        if let Some(new_name) = data.name.strip_suffix(':') {
+        if let Some(new_name) = data.name.strip_suffix("::") {
+            data.name = format!("{new_name}:");
+        } else if let Some(new_name) = data.name.strip_suffix(':') {
             data.name = new_name.to_string();
             assigned = true;
         }
-        if let Some(new_name) = data.name.strip_suffix('-') {
+        if let Some(new_name) = data.name.strip_suffix("--") {
+            data.name = format!("{new_name}-");
+        } else if let Some(new_name) = data.name.strip_suffix('-') {
             data.name = new_name.to_string();
             prefixed = true;
         }

--- a/src/param.rs
+++ b/src/param.rs
@@ -128,7 +128,7 @@ impl Param for FlagOptionParam {
         if self.prefixed || self.data.name.ends_with('-') {
             name_suffix.push('-');
         }
-        if self.assigned || self.data.name.ends_with(":") {
+        if self.assigned || self.data.name.ends_with(':') {
             name_suffix.push(':');
         }
         output.push(format!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -846,6 +846,10 @@ mod tests {
         assert_parse_option_arg!("--foo!");
         assert_parse_option_arg!("--foo-*");
         assert_parse_option_arg!("--foo-");
+        assert_parse_option_arg!("--foo--");
+        assert_parse_option_arg!("--foo:*");
+        assert_parse_option_arg!("--foo:");
+        assert_parse_option_arg!("--foo::");
         assert_parse_option_arg!("--foo=a");
         assert_parse_option_arg!("--foo=`_foo`");
         assert_parse_option_arg!("--foo[a|b]");

--- a/tests/snapshots/integration__spec__option_assigned.snap
+++ b/tests/snapshots/integration__spec__option_assigned.snap
@@ -41,3 +41,16 @@ argc__positionals=( v1 )
 argc__args=([0]="prog" [1]="--oc" [2]="v1")
 argc__positionals=([0]="v1")
 argc_oc=
+
+************ RUN ************
+prog --o: v1
+
+# OUTPUT
+argc_o_=v1
+argc__args=( prog --o: v1 )
+argc__positionals=(  )
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="--o:" [2]="v1")
+argc__positionals=()
+argc_o_=v1

--- a/tests/snapshots/integration__spec__option_prefixed.snap
+++ b/tests/snapshots/integration__spec__option_prefixed.snap
@@ -2,7 +2,7 @@
 source: tests/spec.rs
 expression: data
 ---
-RUN
+************ RUN ************
 prog -o1 -Dv1=foo -Dv2 bar
 
 # OUTPUT
@@ -14,7 +14,18 @@ argc_D["v2"]=bar
 argc__args=( prog -o1 '-Dv1=foo' -Dv2 bar )
 argc__positionals=(  )
 
-# BUILD_OUTPUT
+# RUN_OUTPUT
 error: unexpected argument `-o1` found
 
+************ RUN ************
+prog -v-
 
+# OUTPUT
+argc_v_=1
+argc__args=( prog -v- )
+argc__positionals=(  )
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="-v-")
+argc__positionals=()
+argc_v_=1

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -224,8 +224,15 @@ fn option_prefixed() {
     let script = r###"
 # @option -o-
 # @option -D-*
+# @flag -v--
 "###;
-    snapshot!(script, &["prog", "-o1", "-Dv1=foo", "-Dv2", "bar"]);
+    snapshot_multi!(
+        script,
+        [
+            vec!["prog", "-o1", "-Dv1=foo", "-Dv2", "bar"],
+            vec!["prog", "-v-"]
+        ]
+    );
 }
 
 #[test]
@@ -234,6 +241,7 @@ fn option_assigned() {
 # @option --oa:
 # @option --ob:*
 # @option --oc: <VALUE?>
+# @option --o::
 "###;
     snapshot_multi!(
         script,
@@ -241,6 +249,7 @@ fn option_assigned() {
             vec!["prog", "--oa=v1", "--ob=1", "--ob=2"],
             vec!["prog", "--oa", "v1"],
             vec!["prog", "--oc", "v1"],
+            vec!["prog", "--o:", "v1"],
         ]
     );
 }


### PR DESCRIPTION
use `-` to mark prefixed option, but use `--` to escape name ends with `-`
use `:` to mark assiged option, but use `::` to escape name ends with `:`

```sh
# @option --oa1-
# @option --oa2--
# @option --ob1:
# @option --ob2::
```
```
USAGE: prog [OPTIONS]

OPTIONS:
      --oa1 <OA1>
      --oa2- <OA2>
      --ob1=<OB1>
      --ob2: <OB2:>
```

```sh
prog --oax1 v1 --oax2 v2 
prog --oa2- v1
prog --ob1=v1
prog --ob2: v1
```