### PR TITLE
feat: improve default subcommand

### DIFF
--- a/docs/task-runner.md
+++ b/docs/task-runner.md
@@ -101,6 +101,17 @@ main() {
 }
 ```
 
+Another way is to use `@meta default-subcommand`
+
+```sh
+# @cmd
+# @meta default-subcommand
+build() { :; }
+
+# @cmd
+test() { :; }
+```
+
 Remember, you can always use `--help` for detailed help information.
 
 ## Aliases

--- a/src/build.rs
+++ b/src/build.rs
@@ -322,7 +322,7 @@ _argc_version{suffix}() {{
 
 fn build_parse(cmd: &Command, suffix: &str) -> String {
     let mut parse_help = {
-        let help_flags = cmd.help_flags().join(" | ");
+        let help_flags = cmd.help_flags.join(" | ");
         format!(
             r#"
         {help_flags})
@@ -331,7 +331,7 @@ fn build_parse(cmd: &Command, suffix: &str) -> String {
         )
     };
     let parse_version = if cmd.exist_version() {
-        let version_flags = cmd.version_flags().join(" | ");
+        let version_flags = cmd.version_flags.join(" | ");
         format!(
             r#"
         {version_flags})

--- a/src/param.rs
+++ b/src/param.rs
@@ -430,6 +430,22 @@ impl FlagOptionParam {
         self.inherited = true;
     }
 
+    pub(crate) fn create_help_flag(short: Option<&str>, long_prefix: &str, describe: &str) -> Self {
+        let mut param_data = ParamData::new("help");
+        param_data.describe = describe.to_string();
+        FlagOptionParam::new(param_data, true, short, long_prefix, &[])
+    }
+
+    pub(crate) fn create_version_flag(
+        short: Option<&str>,
+        long_prefix: &str,
+        describe: &str,
+    ) -> Self {
+        let mut param_data = ParamData::new("version");
+        param_data.describe = describe.to_string();
+        FlagOptionParam::new(param_data, true, short, long_prefix, &[])
+    }
+
     pub(crate) fn match_prefix<'a>(&self, arg: &'a str) -> Option<&'a str> {
         if self.prefixed {
             self.list_names().iter().find_map(|v| {

--- a/tests/snapshots/integration__spec__default_subcommand.snap
+++ b/tests/snapshots/integration__spec__default_subcommand.snap
@@ -9,6 +9,14 @@ prog -h
 command cat >&2 <<-'EOF' 
 USAGE: prog <COMMAND>
 
+ARGS:
+  [VAL]
+
+OPTIONS:
+  -h, --help
+  -V, --version
+      --fa
+
 COMMANDS:
   cmda  [default]
   cmdb
@@ -19,14 +27,67 @@ exit 0
 # RUN_OUTPUT
 USAGE: prog <COMMAND>
 
+ARGS:
+  [VAL]
+
+OPTIONS:
+  -h, --help
+  -V, --version
+      --fa
+
 COMMANDS:
   cmda  [default]
   cmdb
 
 ************ RUN ************
+prog --fa
+
+# OUTPUT
+argc_fa=1
+argc__args=( prog --fa )
+argc__fn=cmda
+argc__positionals=(  )
+cmda
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="--fa")
+argc__fn=cmda
+argc__positionals=()
+argc_fa=1
+cmda
+
+************ RUN ************
+prog --fa -h
+
+# OUTPUT
+command cat >&2 <<-'EOF' 
+USAGE: prog cmda [OPTIONS] [VAL]
+
+ARGS:
+  [VAL]
+
+OPTIONS:
+      --fa
+  -h, --help
+
+EOF
+exit 0
+
+# RUN_OUTPUT
+USAGE: prog cmda [OPTIONS] [VAL]
+
+ARGS:
+  [VAL]
+
+OPTIONS:
+      --fa
+  -h, --help
+
+************ RUN ************
 prog v1
 
 # OUTPUT
+argc_val=v1
 argc__args=( prog v1 )
 argc__fn=cmda
 argc__positionals=( v1 )
@@ -36,12 +97,14 @@ cmda v1
 argc__args=([0]="prog" [1]="v1")
 argc__fn=cmda
 argc__positionals=([0]="v1")
+argc_val=v1
 cmda v1
 
 ************ RUN ************
 prog cmda v1
 
 # OUTPUT
+argc_val=v1
 argc__args=( prog cmda v1 )
 argc__fn=cmda
 argc__positionals=( v1 )
@@ -51,6 +114,7 @@ cmda v1
 argc__args=([0]="prog" [1]="cmda" [2]="v1")
 argc__fn=cmda
 argc__positionals=([0]="v1")
+argc_val=v1
 cmda v1
 
 ************ RUN ************
@@ -67,5 +131,3 @@ argc__args=([0]="prog" [1]="cmdb" [2]="v1")
 argc__fn=cmdb
 argc__positionals=([0]="v1")
 cmdb v1
-
-

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -371,6 +371,8 @@ fn default_subcommand() {
     let script = r###"
 # @cmd
 # @meta default-subcommand
+# @flag --fa
+# @arg val
 cmda() { :; }
 
 # @cmd
@@ -380,6 +382,8 @@ cmdb() { :; }
         script,
         [
             vec!["prog", "-h"],
+            vec!["prog", "--fa"],
+            vec!["prog", "--fa", "-h"],
             vec!["prog", "v1"],
             vec!["prog", "cmda", "v1"],
             vec!["prog", "cmdb", "v1"],


### PR DESCRIPTION
1. The help for parent command contains the parameters of the default subcommand.
2. If no arguments are passed, the default subcommand is executed instead of printing help.
3. It is possible to pass flags/options to the default subcommand.