### PR TITLE
feat: abandon no-inherit-env meta

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -178,7 +178,6 @@ Adds metadata.
 | `@meta require-tools <tool>,...` | any    | Require certain tools to be available on the system.                 |
 | `@meta man-section <1-8>`        | root   | Override the section for the man page, defaulting to 1.              |
 | `@meta inherit-flag-options`     | root   | Subcommands will inherit the flags/options from their parent.        |
-| `@meta no-inherit-env`           | subcmd | Subcommands will not inherit the @env from their parent.             |
 | `@meta combine-shorts`           | root   | Short flags/options can be combined, e.g. `prog -xf => prog -x -f `. |
 | `@meta symbol <param>`           | any    | Define a symbolic parameter, e.g. `+toolchain`, `@argument-file`.    |
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -12,8 +12,8 @@ use crate::param::{
 use crate::parser::{parse, parse_symbol, Event, EventData, EventScope, Position};
 use crate::utils::{
     AFTER_HOOK, BEFORE_HOOK, INTERNAL_SYMBOL, MAIN_NAME, META_AUTHOR, META_COMBINE_SHORTS,
-    META_DEFAULT_SUBCOMMAND, META_DOTENV, META_INHERIT_FLAG_OPTIONS, META_NO_INHERIT_ENV,
-    META_REQUIRE_TOOLS, META_SYMBOL, META_VERSION, ROOT_NAME,
+    META_DEFAULT_SUBCOMMAND, META_DOTENV, META_INHERIT_FLAG_OPTIONS, META_REQUIRE_TOOLS,
+    META_SYMBOL, META_VERSION, ROOT_NAME,
 };
 use crate::Result;
 
@@ -60,9 +60,7 @@ impl Command {
         if root.has_metadata(META_INHERIT_FLAG_OPTIONS) {
             root.inherit_flag_options();
         }
-        if !root.has_metadata(META_NO_INHERIT_ENV) {
-            root.inherit_envs();
-        }
+        root.inherit_envs();
         Ok(root)
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,6 @@ pub(crate) const META_AUTHOR: &str = "author";
 pub(crate) const META_DOTENV: &str = "dotenv";
 pub(crate) const META_DEFAULT_SUBCOMMAND: &str = "default-subcommand";
 pub(crate) const META_INHERIT_FLAG_OPTIONS: &str = "inherit-flag-options";
-pub(crate) const META_NO_INHERIT_ENV: &str = "no-inherit-env";
 pub(crate) const META_SYMBOL: &str = "symbol";
 pub(crate) const META_COMBINE_SHORTS: &str = "combine-shorts";
 pub(crate) const META_MAN_SECTION: &str = "man-section";


### PR DESCRIPTION
The command should always inherit its parent env param.