### PR TITLE
refactor: omit choices/default/env info if description already contains

### DIFF
--- a/tests/snapshots/integration__env__env_help.snap
+++ b/tests/snapshots/integration__env__env_help.snap
@@ -16,7 +16,7 @@ ENVIRONMENTS:
   TEST_EDA  default [default: a]
   TEST_EDB  default from fn
   TEST_ECA  choice [possible values: a, b]
-  TEST_ECB  choice + default [default: a] [possible values: a, b]
+  TEST_ECB  choice + default [possible values: a, b] [default: a]
   TEST_EFA  choice from fn
 
 
@@ -35,5 +35,5 @@ ENVIRONMENTS:
   TEST_EDA  default [default: a]
   TEST_EDB  default from fn
   TEST_ECA  choice [possible values: a, b]
-  TEST_ECB  choice + default [default: a] [possible values: a, b]
+  TEST_ECB  choice + default [possible values: a, b] [default: a]
   TEST_EFA  choice from fn

--- a/tests/snapshots/integration__env__env_help_subcmd.snap
+++ b/tests/snapshots/integration__env__env_help_subcmd.snap
@@ -10,7 +10,7 @@ ENVIRONMENTS:
   TEST_EDA  default [default: a]
   TEST_EDB  default from fn
   TEST_ECA  choice [possible values: a, b]
-  TEST_ECB  choice + default [default: a] [possible values: a, b]
+  TEST_ECB  choice + default [possible values: a, b] [default: a]
   TEST_EFA  choice from fn
   TEST_EA   override
   TEST_NEW  append
@@ -25,7 +25,7 @@ ENVIRONMENTS:
   TEST_EDA  default [default: a]
   TEST_EDB  default from fn
   TEST_ECA  choice [possible values: a, b]
-  TEST_ECB  choice + default [default: a] [possible values: a, b]
+  TEST_ECB  choice + default [possible values: a, b] [default: a]
   TEST_EFA  choice from fn
   TEST_EA   override
   TEST_NEW  append

--- a/tests/snapshots/integration__multiline__nowrap.snap
+++ b/tests/snapshots/integration__multiline__nowrap.snap
@@ -27,8 +27,6 @@ OPTIONS:
            * default: enables recommended style components.
            * full: enables all available components.
            * auto: same as 'default', unless the output is piped.
-          [default: default]
-          [possible values: default, full, auto]
 
       --bar <BAR>
           Eager dogs jump quickly over the lazy brown fox, swiftly running past green fields, but only until the night turns dark. Bright stars sparkle clearly above us now.
@@ -66,8 +64,6 @@ OPTIONS:
            * default: enables recommended style components.
            * full: enables all available components.
            * auto: same as 'default', unless the output is piped.
-          [default: default]
-          [possible values: default, full, auto]
 
       --bar <BAR>
           Eager dogs jump quickly over the lazy brown fox, swiftly running past green fields, but only until the night turns dark. Bright stars sparkle clearly above us now.

--- a/tests/snapshots/integration__multiline__wrap.snap
+++ b/tests/snapshots/integration__multiline__wrap.snap
@@ -33,8 +33,6 @@ OPTIONS:
            * default: enables recommended style components.
            * full: enables all available components.
            * auto: same as 'default', unless the output is piped.
-          [default: default]
-          [possible values: default, full, auto]
 
       --bar <BAR>
           Eager dogs jump quickly over the lazy brown fox, swiftly running
@@ -76,8 +74,6 @@ OPTIONS:
            * default: enables recommended style components.
            * full: enables all available components.
            * auto: same as 'default', unless the output is piped.
-          [default: default]
-          [possible values: default, full, auto]
 
       --bar <BAR>
           Eager dogs jump quickly over the lazy brown fox, swiftly running past green fields, but only until the night turns dark. Bright stars sparkle clearly above us now.

--- a/tests/snapshots/integration__multiline__wrap2.snap
+++ b/tests/snapshots/integration__multiline__wrap2.snap
@@ -33,8 +33,6 @@ OPTIONS:
            * default: enables recommended style components.
            * full: enables all available components.
            * auto: same as 'default', unless the output is piped.
-          [default: default]
-          [possible values: default, full, auto]
 
       --bar <BAR>
           Eager dogs jump quickly over the lazy brown fox, swiftly running
@@ -76,8 +74,6 @@ OPTIONS:
            * default: enables recommended style components.
            * full: enables all available components.
            * auto: same as 'default', unless the output is piped.
-          [default: default]
-          [possible values: default, full, auto]
 
       --bar <BAR>
           Eager dogs jump quickly over the lazy brown fox, swiftly running past green fields, but only until the night turns dark. Bright stars sparkle clearly above us now.

--- a/tests/snapshots/integration__spec__arg_subcmd_help.snap
+++ b/tests/snapshots/integration__spec__arg_subcmd_help.snap
@@ -169,7 +169,7 @@ command cat >&2 <<-'EOF'
 USAGE: prog cmd_arg_with_choices_and_default [VAL]
 
 ARGS:
-  [VAL]  [default: x] [possible values: x, y, z]
+  [VAL]  [possible values: x, y, z] [default: x]
 
 EOF
 exit 0
@@ -178,7 +178,7 @@ exit 0
 USAGE: prog cmd_arg_with_choices_and_default [VAL]
 
 ARGS:
-  [VAL]  [default: x] [possible values: x, y, z]
+  [VAL]  [possible values: x, y, z] [default: x]
 
 ************ RUN ************
 prog cmd_multi_arg_with_choices -h
@@ -432,5 +432,3 @@ ARGS:
   <VAL1>
   <VAL2>
   <VAL3>
-
-

--- a/tests/snapshots/integration__spec__option_help.snap
+++ b/tests/snapshots/integration__spec__option_help.snap
@@ -25,7 +25,7 @@ OPTIONS:
       --oda <ODA>          default [default: a]
       --odb <ODB>          default from fn
       --oca <OCA>          choice [possible values: a, b]
-      --ocb <OCB>          choice + default [default: a] [possible values: a, b]
+      --ocb <OCB>          choice + default [possible values: a, b] [default: a]
       --occ [OCC]...       multi-occurs + choice [possible values: a, b]
       --ofa <OFA>          choice from fn
       --ofb <OFB>          choice from fn + no validation
@@ -56,7 +56,7 @@ OPTIONS:
       --oda <ODA>          default [default: a]
       --odb <ODB>          default from fn
       --oca <OCA>          choice [possible values: a, b]
-      --ocb <OCB>          choice + default [default: a] [possible values: a, b]
+      --ocb <OCB>          choice + default [possible values: a, b] [default: a]
       --occ [OCC]...       multi-occurs + choice [possible values: a, b]
       --ofa <OFA>          choice from fn
       --ofb <OFB>          choice from fn + no validation
@@ -188,7 +188,7 @@ OPTIONS:
        +oda <ODA>          default [default: a]
        +odb <ODB>          default from fn
        +oca <OCA>          choice [possible values: a, b]
-       +ocb <OCB>          choice + default [default: a] [possible values: a, b]
+       +ocb <OCB>          choice + default [possible values: a, b] [default: a]
        +occ [OCC]...       multi-occurs + choice [possible values: a, b]
        +ocd <OCD>...       required + multi-occurs + choice [possible values: a, b]
        +ofa <OFA>          choice from fn
@@ -219,7 +219,7 @@ OPTIONS:
        +oda <ODA>          default [default: a]
        +odb <ODB>          default from fn
        +oca <OCA>          choice [possible values: a, b]
-       +ocb <OCB>          choice + default [default: a] [possible values: a, b]
+       +ocb <OCB>          choice + default [possible values: a, b] [default: a]
        +occ [OCC]...       multi-occurs + choice [possible values: a, b]
        +ocd <OCD>...       required + multi-occurs + choice [possible values: a, b]
        +ofa <OFA>          choice from fn
@@ -435,7 +435,7 @@ USAGE: prog test3 [OPTIONS]
 OPTIONS:
       --oe <OE>  [default: val]
       --of <OF>
-      --cb <CB>  [default: x] [possible values: x, y, z]
+      --cb <CB>  [possible values: x, y, z] [default: x]
   -h, --help
 
 EOF
@@ -447,5 +447,5 @@ USAGE: prog test3 [OPTIONS]
 OPTIONS:
       --oe <OE>  [default: val]
       --of <OF>
-      --cb <CB>  [default: x] [possible values: x, y, z]
+      --cb <CB>  [possible values: x, y, z] [default: x]
   -h, --help


### PR DESCRIPTION

```diff
      --foo <FOO>
          Sunshine gleams over hills afar, bringing warmth and hope to every soul, yet challenges await as we journey forth, striving for dreams and joy in abundance. Peaceful rivers whisper secrets gently heard.
           * default: enables recommended style components.
           * full: enables all available components.
           * auto: same as 'default', unless the output is piped.
--          [default: default]
--          [possible values: default, full, auto]
```
Since description already contains possible values and default, omit it smartly.