### PR TITLE
refactor: improve invalid subcommand error message

### DIFF
--- a/tests/snapshots/integration__main_fn__global_without_arg.snap
+++ b/tests/snapshots/integration__main_fn__global_without_arg.snap
@@ -7,7 +7,7 @@ prog abc
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-error: `prog` requires a subcommand but one was not provided
+error: `prog` requires a subcommand but 'abc' is not one of them
   [subcommands: cmd]
 EOF
 exit 1
@@ -15,5 +15,3 @@ exit 1
 # BUILD_OUTPUT
 error: `prog` requires a subcommand but one was not provided
   [subcommands: cmd]
-
-


### PR DESCRIPTION
Now argc tells the argument doesn't match the subcommand.

```diff
- `prog` requires a subcommand but one was not provided␊
+ `prog` requires a subcommand but 'abc' is not one of them␊
```