### PR TITLE
feat: auto alias subcmds with hyphens for underscores 

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -496,6 +496,19 @@ impl Command {
     fn update_recursively(&mut self, paths: Vec<String>, mut require_tools: IndexSet<String>) {
         self.paths.clone_from(&paths);
 
+        // auto alias if command name contains `_`
+        if let Some(name) = self.name.clone() {
+            let compatible_name = name.replace('_', "-");
+            if compatible_name != name {
+                match self.aliases.as_mut() {
+                    Some((aliaes, _)) => aliaes.insert(0, compatible_name),
+                    None => {
+                        self.aliases = Some((vec![compatible_name], Position::default()));
+                    }
+                }
+            }
+        }
+
         // update command_fn
         if paths.is_empty() {
             if self.share.borrow().fns.contains_key(MAIN_NAME) {

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -820,6 +820,16 @@ _choice_fn() {
 }
 
 #[test]
+fn auto_alias_subcommand() {
+    let script = r###"
+# @cmd
+cmd_a() { :; }
+"###;
+
+    snapshot_compgen!(script, [vec!["prog", ""], vec!["prog", "cmd"]]);
+}
+
+#[test]
 fn multi_char() {
     let script = r#"
 # @option --oa*,[`_choice_fn`]

--- a/tests/snapshots/integration__compgen__auto_alias_subcommand.snap
+++ b/tests/snapshots/integration__compgen__auto_alias_subcommand.snap
@@ -1,0 +1,12 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog ` ************
+cmd_a	/color:magenta
+cmd-a	/color:magenta
+help	/color:magenta
+
+************ COMPGEN `prog cmd` ************
+cmd_a	/color:magenta
+cmd-a	/color:magenta

--- a/tests/snapshots/integration__spec__auto_alias_subcommand.snap
+++ b/tests/snapshots/integration__spec__auto_alias_subcommand.snap
@@ -1,0 +1,52 @@
+---
+source: tests/spec.rs
+expression: data
+---
+************ RUN ************
+prog -h
+
+# OUTPUT
+command cat >&2 <<-'EOF' 
+USAGE: prog <COMMAND>
+
+COMMANDS:
+  cmd_a  [aliases: cmd-a]
+
+EOF
+exit 0
+
+# RUN_OUTPUT
+USAGE: prog <COMMAND>
+
+COMMANDS:
+  cmd_a  [aliases: cmd-a]
+
+************ RUN ************
+prog cmd_a
+
+# OUTPUT
+argc__args=( prog cmd_a )
+argc__fn=cmd_a
+argc__positionals=(  )
+cmd_a
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="cmd_a")
+argc__fn=cmd_a
+argc__positionals=()
+cmd_a
+
+************ RUN ************
+prog cmd-a
+
+# OUTPUT
+argc__args=( prog cmd-a )
+argc__fn=cmd_a
+argc__positionals=(  )
+cmd_a
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="cmd-a")
+argc__fn=cmd_a
+argc__positionals=()
+cmd_a

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -390,3 +390,19 @@ cmdb() { :; }
         ]
     );
 }
+
+#[test]
+fn auto_alias_subcommand() {
+    let script = r###"
+# @cmd
+cmd_a() { :; }
+"###;
+    snapshot_multi!(
+        script,
+        [
+            vec!["prog", "-h"],
+            vec!["prog", "cmd_a"],
+            vec!["prog", "cmd-a"],
+        ]
+    );
+}


### PR DESCRIPTION
If the subcommand name contains `_`, argc will automaticly generate a alias (`_` => `-`) for it.

```
#!/bin/bash
set -e

# @cmd
foo_bar() {
    echo OK
}

eval "$(argc --argc-eval "$0" "$@")"
```

```
$ prog -h
USAGE: prog<COMMAND>

COMMANDS:
  foo_bar  [aliases: foo-bar]

$ prog foo_bar
OK

$ grog foo-bar
OK
```