### PR TITLE
fix: powershell completion script

### DIFF
--- a/src/completions/argc.ps1
+++ b/src/completions/argc.ps1
@@ -2,7 +2,15 @@ using namespace System.Management.Automation
 
 $_argc_completer = {
     param($wordToComplete, $commandAst, $cursorPosition)
-    $words = @($commandAst.CommandElements | Where { $_.Extent.StartOffset -lt $cursorPosition } | ForEach-Object { $_.ToString() })
+    $words = @($commandAst.CommandElements | Where { $_.Extent.StartOffset -lt $cursorPosition } | ForEach-Object {
+        $word =  $_.ToString() 
+        if ($word.Length -gt 2) {
+            if (($word.StartsWith('"') -and $word.EndsWith('"')) -or ($word.StartsWith("'") -and $word.EndsWith("'"))) {
+                $word = $word.Substring(1, $word.Length - 2)
+            }
+        }
+        return $word
+    })
     $emptyS = ''
     if ($PSVersionTable.PSVersion.Major -eq 5) {
         $emptyS = '""'


### PR DESCRIPTION
Argc compgen on powershell does not works if subcommands contain quotes

```
argc 'build@tool' <tab>
```

The powershell completion script take args `["'build@tool'", " "]`.  `'build@tool'` does not match `build@tool`.

The PR fixs the bug.