### PR TITLE
fix: incorrectly handle args that startswith `-` but are not flags/options

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -370,7 +370,7 @@ impl Command {
         }
     }
 
-    pub(crate) fn flag_option_signs(&self) -> String {
+    pub(crate) fn flag_option_signs(&self) -> IndexSet<char> {
         let mut signs: IndexSet<char> = ['-'].into();
         for param in &self.flag_option_params {
             if let Some(short) = param.short() {
@@ -378,7 +378,7 @@ impl Command {
             }
             signs.extend(param.long_prefix().chars().take(1))
         }
-        signs.into_iter().collect()
+        signs
     }
 
     pub(crate) fn cmd_name(&self) -> String {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -398,7 +398,14 @@ fn parse_with_long_head(input: &str) -> nom::IResult<&str, (Option<&str>, &str)>
                 ),
                 peek(space1),
             )),
-            preceded(space0, alt((tag("--"), tag("-"), tag("+")))),
+            preceded(
+                space0,
+                alt((
+                    terminated(tag("--"), peek(not(char('-')))),
+                    terminated(tag("-"), peek(not(char('-')))),
+                    terminated(tag("+"), peek(not(char('+')))),
+                )),
+            ),
         ),)),
         |(short, long_prefix)| (short.map(|_| &input[0..2]), long_prefix),
     )(input)
@@ -1047,6 +1054,8 @@ mod tests {
             Ok(("foo", (Some("+f"), "+")))
         );
         assert_eq!(parse_with_long_head("+foo"), Ok(("foo", (None, "+"))));
+        assert!(parse_with_long_head("-f ---foo").is_err());
+        assert!(parse_with_long_head("+f ++foo").is_err());
     }
 
     #[test]

--- a/tests/snapshots/integration__spec__option_value_dash.snap
+++ b/tests/snapshots/integration__spec__option_value_dash.snap
@@ -27,15 +27,12 @@ argc__args=([0]="prog" [1]="---")
 argc__positionals=([0]="---")
 
 ************ RUN ************
-prog --a
-b
+prog --a b
 
 # OUTPUT
-argc__args=( prog '--a
-b' )
-argc__positionals=( '--a
-b' )
+argc__args=( prog '--a b' )
+argc__positionals=( '--a b' )
 
 # RUN_OUTPUT
-argc__args=([0]="prog" [1]=$'--a\nb')
-argc__positionals=([0]=$'--a\nb')
+argc__args=([0]="prog" [1]="--a b")
+argc__positionals=([0]="--a b")

--- a/tests/snapshots/integration__spec__option_value_dash.snap
+++ b/tests/snapshots/integration__spec__option_value_dash.snap
@@ -1,0 +1,41 @@
+---
+source: tests/spec.rs
+expression: data
+---
+************ RUN ************
+prog --oa ---
+
+# OUTPUT
+argc_oa=---
+argc__args=( prog --oa --- )
+argc__positionals=(  )
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="--oa" [2]="---")
+argc__positionals=()
+argc_oa=---
+
+************ RUN ************
+prog ---
+
+# OUTPUT
+argc__args=( prog --- )
+argc__positionals=( --- )
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="---")
+argc__positionals=([0]="---")
+
+************ RUN ************
+prog --a
+b
+
+# OUTPUT
+argc__args=( prog '--a
+b' )
+argc__positionals=( '--a
+b' )
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]=$'--a\nb')
+argc__positionals=([0]=$'--a\nb')

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -417,3 +417,18 @@ fn option_single_dash() {
         [vec!["prog", "--oa", "-"], vec!["prog", "--oa", "-", ""],]
     );
 }
+
+#[test]
+fn option_value_dash() {
+    let script = r###"
+# @option --oa
+"###;
+    snapshot_multi!(
+        script,
+        [
+            vec!["prog", "--oa", "---"],
+            vec!["prog", "---"],
+            vec!["prog", "--a\nb"]
+        ]
+    );
+}

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -428,7 +428,7 @@ fn option_value_dash() {
         [
             vec!["prog", "--oa", "---"],
             vec!["prog", "---"],
-            vec!["prog", "--a\nb"]
+            vec!["prog", "--a b"]
         ]
     );
 }


### PR DESCRIPTION
The following args should be treat as values other than flags/options

```
---
--a b
```
relate to sigoden/llm-functions#94