### PR TITLE
feat: support escaping `@` in the comment

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -783,6 +783,10 @@ fn take_comment_lines(lines: &[&str], idx: usize, output: &mut String) -> usize 
     for line in lines.iter().skip(idx) {
         if let Ok((text, _)) = parse_normal_comment(line) {
             output.push('\n');
+            let text = match text.strip_prefix("\\@") {
+                Some(v) => v,
+                None => text,
+            };
             output.push_str(text);
             count += 1;
         } else {

--- a/tests/snapshots/integration__validate__escape_at_symbol.snap
+++ b/tests/snapshots/integration__validate__escape_at_symbol.snap
@@ -1,0 +1,38 @@
+---
+source: tests/validate.rs
+expression: data
+---
+************ RUN ************
+prog -h
+
+# OUTPUT
+command cat >&2 <<-'EOF' 
+Patch utils
+
+Here is an example of a patch block:
+--- a/hello.py
++++ b/hello.py
+@ ... @@
+ def hello():
+-    print("Hello World")
++    name = input("What is your name? ")
++    print(f"Hello {name}")
+
+USAGE: prog
+
+EOF
+exit 0
+
+# RUN_OUTPUT
+Patch utils
+
+Here is an example of a patch block:
+--- a/hello.py
++++ b/hello.py
+@ ... @@
+ def hello():
+-    print("Hello World")
++    name = input("What is your name? ")
++    print(f"Hello {name}")
+
+USAGE: prog

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -77,6 +77,23 @@ fn help_notations() {
 }
 
 #[test]
+fn escape_at_symbol() {
+    let script = r###"
+# @describe Patch utils
+#
+# Here is an example of a patch block:
+# --- a/hello.py
+# +++ b/hello.py
+# \@@ ... @@
+#  def hello():
+# -    print("Hello World")
+# +    name = input("What is your name? ")
+# +    print(f"Hello {name}")
+"###;
+    snapshot_multi!(script, [vec!["prog", "-h"]]);
+}
+
+#[test]
 fn version_missing() {
     let script = r###"
 # @cmd


### PR DESCRIPTION
If we use `# @` but `@..` is not a valid comment tag, argc will throw an error.

```sh
# @describe Patch utils
# 
# Here is an example of a patch block:
# --- a/hello.py
# +++ b/hello.py
# @@ ... @@
#  def hello():
# -    print("Hello World")
# +    name = input("What is your name? ")
# +    print(f"Hello {name}")

eval "$(argc --argc-eval "$0" "$@")"
```
```
@@(line 8) is unknown tag
```

This PR allow escaping `@` with `\` to avoid such error.
```diff
-# @@ ... @@
+# \@@ ... @@
```
