### PR TITLE
fix: ignore the leading `_` when auto-aliasing subcmds

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -498,7 +498,11 @@ impl Command {
 
         // auto alias if command name contains `_`
         if let Some(name) = self.name.clone() {
-            let compatible_name = name.replace('_', "-");
+            let compatible_name = name
+                .chars()
+                .enumerate()
+                .map(|(i, c)| if i > 0 && c == '_' { '-' } else { c })
+                .collect::<String>();
             if compatible_name != name {
                 match self.aliases.as_mut() {
                     Some((aliaes, _)) => aliaes.insert(0, compatible_name),

--- a/tests/snapshots/integration__spec__auto_alias_subcommand.snap
+++ b/tests/snapshots/integration__spec__auto_alias_subcommand.snap
@@ -11,6 +11,7 @@ USAGE: prog <COMMAND>
 
 COMMANDS:
   cmd_a  [aliases: cmd-a]
+  _cmdb
 
 EOF
 exit 0
@@ -20,6 +21,7 @@ USAGE: prog <COMMAND>
 
 COMMANDS:
   cmd_a  [aliases: cmd-a]
+  _cmdb
 
 ************ RUN ************
 prog cmd_a
@@ -50,3 +52,18 @@ argc__args=([0]="prog" [1]="cmd-a")
 argc__fn=cmd_a
 argc__positionals=()
 cmd_a
+
+************ RUN ************
+prog _cmdb
+
+# OUTPUT
+argc__args=( prog _cmdb )
+argc__fn=_cmdb
+argc__positionals=(  )
+_cmdb
+
+# RUN_OUTPUT
+argc__args=([0]="prog" [1]="_cmdb")
+argc__fn=_cmdb
+argc__positionals=()
+_cmdb

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -396,6 +396,9 @@ fn auto_alias_subcommand() {
     let script = r###"
 # @cmd
 cmd_a() { :; }
+
+# @cmd
+_cmdb() { :; }
 "###;
     snapshot_multi!(
         script,
@@ -403,6 +406,7 @@ cmd_a() { :; }
             vec!["prog", "-h"],
             vec!["prog", "cmd_a"],
             vec!["prog", "cmd-a"],
+            vec!["prog", "_cmdb"],
         ]
     );
 }


### PR DESCRIPTION
Argc supports automatic aliasing for subcommands that contain `_`, but it should ignore the leading `_`.

For example, argc should not auto-alising `_cmd` to `-cmd`.