### PR TITLE
fix: fish completion doesn't work if commandline contains `&&` or `||`

### DIFF
--- a/src/completions/argc.bash
+++ b/src/completions/argc.bash
@@ -1,18 +1,18 @@
 _argc_completer() {
-    local words
+    declare -a _argc_completer_words
     _argc_completer_parse_line
 
     export COMP_WORDBREAKS
     while IFS=$'\n' read -r line; do
         COMPREPLY+=( "$line" )
-    done < <(argc --argc-compgen bash "" "${words[@]}" 2>/dev/null)
+    done < <(argc --argc-compgen bash "" "${_argc_completer_words[@]}" 2>/dev/null)
 }
 
 _argc_completer_parse_line() {
-    local line len i char prev_char word unbalance word_index
-    word_index=0
+    local line len i char prev_char word unbalance
     line="${COMP_LINE:0:$COMP_POINT}"
     len="${#line}"
+
     for ((i=0; i<len; i++)); do
         char="${line:i:1}"
         if [[ -n "$unbalance" ]]; then
@@ -24,8 +24,7 @@ _argc_completer_parse_line() {
             if [[ "$prev_char" == "\\" ]]; then
                 word="$word$char"
             elif [[ -n "$word" ]]; then
-                words[$word_index]="$word"
-                word_index=$((word_index+1))
+                _argc_completer_words+=( "$word" )
                 word=""
             fi
         elif [[ "$char" == "'" || "$char" == '"' ]]; then
@@ -40,7 +39,8 @@ _argc_completer_parse_line() {
         fi
         prev_char="$char"
     done
-    words[$word_index]="$word"
+
+    _argc_completer_words+=( "$word" )
 }
 
 complete -F _argc_completer -o nospace -o nosort \

--- a/src/completions/argc.fish
+++ b/src/completions/argc.fish
@@ -1,11 +1,46 @@
 function _argc_completer
-    set -l args (commandline -o)
-    set -l cur (commandline -t)
-    if [ ! "$cur" ]
-        set -a args ''
+    set -g _argc_completer_words
+    _argc_completer_parse_line
+
+    argc --argc-compgen fish "" $_argc_completer_words
+end
+
+function _argc_completer_parse_line
+    set -l line (commandline -cp) 
+    set -l word ''
+    set -l unbalance ''
+    set -l prev_char ''
+
+    for i in (seq (string length -- $line))
+        set -l char (string sub -s $i -l 1 -- $line)
+
+        if test -n "$unbalance"
+            set word "$word$char"
+            if test "$unbalance" = "$char"
+                set unbalance ''
+            end
+        else if test "$char" = ' '
+            if test "$prev_char" = '\\'
+                set word "$word$char"
+            else if test -n "$word"
+                set -a _argc_completer_words "$word"
+                set word ''
+            end
+        else if test "$char" = "'" -o "$char" = '"'
+            set word "$word$char"
+            set unbalance "$char"
+        else if test "$char" = '\\'
+            if test "$prev_char" = '\\'
+                set word "$word$char"
+            end
+        else
+            set word "$word$char"
+        end
+
+        set prev_char "$char"
     end
 
-    argc --argc-compgen fish "" $args
+    set -a _argc_completer_words "$word"
 end
 
 


### PR DESCRIPTION
close #365 
