### PR TITLE
feat: abandon support for author meta

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -174,7 +174,6 @@ Adds metadata.
 | syntax                           | scope  | description                                                          |
 | :------------------------------- | ------ | :------------------------------------------------------------------- |
 | `@meta version <value>`          | any    | Set the version for the command.                                     |
-| `@meta author <value>`           | any    | Set the author for the command.                                      |
 | `@meta dotenv [<path>]`          | root   | Load a dotenv file from a custom path, if persent.                   |
 | `@meta default-subcommand`       | subcmd | Set the current subcommand as the default.                           |
 | `@meta require-tools <tool>,...` | any    | Require certain tools to be available on the system.                 |
@@ -186,7 +185,6 @@ Adds metadata.
 
 ```sh
 # @meta version 1.0.0
-# @meta author nobody <nobody@example.com>
 # @meta dotenv
 # @meta dotenv .env.local
 # @meta require-tools git,yq

--- a/examples/multiline.sh
+++ b/examples/multiline.sh
@@ -4,7 +4,6 @@
 # are treated as the long description. A line which is not a comment ends the block.
 
 # @meta version 1.0.0
-# @meta author  nobody <nobody@example.com>
 
 # @option --foo[=default|full|auto] Sunshine gleams over hills afar, bringing warmth and hope to every soul, yet challenges await as we journey forth, striving for dreams and joy in abundance. Peaceful rivers whisper secrets gently heard.
 #  * default: enables recommended style components.

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -13,9 +13,8 @@ use crate::param::{EnvValue, FlagOptionValue, PositionalValue};
 use crate::parser::{parse, parse_symbol, Event, EventData, EventScope, Position};
 use crate::runtime::Runtime;
 use crate::utils::{
-    AFTER_HOOK, BEFORE_HOOK, MAIN_NAME, META_AUTHOR, META_COMBINE_SHORTS, META_DEFAULT_SUBCOMMAND,
-    META_DOTENV, META_INHERIT_FLAG_OPTIONS, META_REQUIRE_TOOLS, META_SYMBOL, META_VERSION,
-    ROOT_NAME,
+    AFTER_HOOK, BEFORE_HOOK, MAIN_NAME, META_COMBINE_SHORTS, META_DEFAULT_SUBCOMMAND, META_DOTENV,
+    META_INHERIT_FLAG_OPTIONS, META_REQUIRE_TOOLS, META_SYMBOL, META_VERSION, ROOT_NAME,
 };
 use crate::Result;
 
@@ -41,7 +40,6 @@ pub(crate) struct Command {
     pub(crate) subcommand_fns: HashMap<String, Position>,
     pub(crate) default_subcommand: Option<(usize, Position)>,
     pub(crate) aliases: Option<(Vec<String>, Position)>,
-    pub(crate) author: Option<String>,
     pub(crate) version: Option<String>,
     pub(crate) names_checker: NamesChecker,
     pub(crate) share: Arc<RefCell<ShareData>>,
@@ -145,7 +143,6 @@ impl Command {
         CommandValue {
             name: self.cmd_name(),
             describe: self.describe.clone(),
-            author: self.author.clone(),
             version: self.version.clone(),
             aliases: self.list_alias_names().clone(),
             flag_options,
@@ -170,10 +167,6 @@ impl Command {
                     let cmd = Self::get_cmd(&mut root_cmd, "@version", position)?;
                     cmd.version = Some(value);
                 }
-                EventData::Author(value) => {
-                    let cmd = Self::get_cmd(&mut root_cmd, "@author", position)?;
-                    cmd.author = Some(value);
-                }
                 EventData::Meta(key, value) => {
                     let cmd = Self::get_cmd(&mut root_cmd, "@meta", position)?;
                     match key.as_str() {
@@ -189,13 +182,6 @@ impl Command {
                                 bail!("@meta(line {}) invalid version value", position)
                             } else {
                                 cmd.version = Some(value.clone());
-                            }
-                        }
-                        META_AUTHOR => {
-                            if value.is_empty() {
-                                bail!("@meta(line {}) invalid version value", position)
-                            } else {
-                                cmd.author = Some(value.clone());
                             }
                         }
                         _ => {}
@@ -701,9 +687,6 @@ impl Command {
         if self.version.is_some() {
             output.push(self.render_version());
         }
-        if let Some(author) = &self.author {
-            output.push(author.to_string());
-        }
         if !&self.describe.is_empty() {
             output.push(render_block("", &self.describe, wrap_width));
         }
@@ -872,7 +855,6 @@ impl Command {
 pub struct CommandValue {
     pub name: String,
     pub describe: String,
-    pub author: Option<String>,
     pub version: Option<String>,
     pub aliases: Vec<String>,
     pub flag_options: Vec<FlagOptionValue>,

--- a/src/mangen.rs
+++ b/src/mangen.rs
@@ -30,7 +30,6 @@ fn render_manpage(cmd: &Command, section: &str) -> String {
     render_subcommands_section(&mut roff, cmd, section);
     render_envs_section(&mut roff, cmd);
     render_version_section(&mut roff, cmd);
-    render_author_section(&mut roff, cmd);
     roff.to_roff()
 }
 
@@ -193,13 +192,6 @@ fn render_version_section(roff: &mut Roff, cmd: &Command) {
     if let Some(version) = &cmd.version {
         roff.control("SH", ["VERSION"]);
         roff.text([roman(version)]);
-    }
-}
-
-fn render_author_section(roff: &mut Roff, cmd: &Command) {
-    if let Some(author) = &cmd.author {
-        roff.control("SH", ["AUTHORS"]);
-        roff.text([roman(author)]);
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,8 +31,6 @@ pub(crate) enum EventData {
     Describe(String),
     /// Version info
     Version(String),
-    /// Author info
-    Author(String),
     /// Metadata
     Meta(String, String),
     /// Define a subcommand, e.g. `@cmd A sub command`
@@ -158,7 +156,7 @@ fn parse_tag(input: &str) -> nom::IResult<&str, Option<EventData>> {
 fn parse_tag_text(input: &str) -> nom::IResult<&str, Option<EventData>> {
     map(
         pair(
-            alt((tag("describe"), tag("version"), tag("author"), tag("cmd"))),
+            alt((tag("describe"), tag("version"), tag("cmd"))),
             parse_tail,
         ),
         |(tag, text)| {
@@ -166,7 +164,6 @@ fn parse_tag_text(input: &str) -> nom::IResult<&str, Option<EventData>> {
             Some(match tag {
                 "describe" => EventData::Describe(text),
                 "version" => EventData::Version(text),
-                "author" => EventData::Author(text),
                 "cmd" => EventData::Cmd(text),
                 _ => unreachable!(),
             })
@@ -1098,7 +1095,6 @@ mod tests {
     fn test_parse_line() {
         assert_token!("# @describe A demo cli", Describe, "A demo cli");
         assert_token!("# @version 1.0.0", Version, "1.0.0");
-        assert_token!("# @author Somebody", Author, "Somebody");
         assert_token!("# @meta key", Meta, "key", "");
         assert_token!("# @meta key value", Meta, "key", "value");
         assert_token!("# @cmd A subcommand", Cmd, "A subcommand");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,6 @@ pub const ROOT_NAME: &str = "prog";
 pub const MAIN_NAME: &str = "main";
 
 pub(crate) const META_VERSION: &str = "version";
-pub(crate) const META_AUTHOR: &str = "author";
 pub(crate) const META_DOTENV: &str = "dotenv";
 pub(crate) const META_DEFAULT_SUBCOMMAND: &str = "default-subcommand";
 pub(crate) const META_INHERIT_FLAG_OPTIONS: &str = "inherit-flag-options";

--- a/tests/snapshots/integration__cli__export.snap
+++ b/tests/snapshots/integration__cli__export.snap
@@ -5,7 +5,6 @@ expression: stdout
 {
   "name": "options",
   "describe": "All kinds of @option and @flag",
-  "author": null,
   "version": null,
   "aliases": [],
   "flag_options": [
@@ -62,7 +61,6 @@ expression: stdout
     {
       "name": "options",
       "describe": "All kind of options",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -651,7 +649,6 @@ expression: stdout
     {
       "name": "flags",
       "describe": "All kind of flags",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -802,7 +799,6 @@ expression: stdout
     {
       "name": "options-one-hyphen",
       "describe": "Flags or options with single hyphen",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -1044,7 +1040,6 @@ expression: stdout
     {
       "name": "options-notation-modifier",
       "describe": "Value notation modifier",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -1155,7 +1150,6 @@ expression: stdout
     {
       "name": "options-plus",
       "describe": "All kind of options",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -1750,7 +1744,6 @@ expression: stdout
     {
       "name": "flags-plus",
       "describe": "All kind of flags",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -1901,7 +1894,6 @@ expression: stdout
     {
       "name": "options-mixed",
       "describe": "Mixed `-` and `+` options",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -2012,7 +2004,6 @@ expression: stdout
     {
       "name": "options-prefixed",
       "describe": "Prefixed option",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -2110,7 +2101,6 @@ expression: stdout
     {
       "name": "options-assigned",
       "describe": "Prefixed option",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -2177,7 +2167,6 @@ expression: stdout
     {
       "name": "test1",
       "describe": "",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -2629,7 +2618,6 @@ expression: stdout
     {
       "name": "test2",
       "describe": "",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [
@@ -2833,7 +2821,6 @@ expression: stdout
     {
       "name": "test3",
       "describe": "",
-      "author": null,
       "version": null,
       "aliases": [],
       "flag_options": [

--- a/tests/snapshots/integration__multiline__nowrap.snap
+++ b/tests/snapshots/integration__multiline__nowrap.snap
@@ -8,7 +8,6 @@ prog -h
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with an `@`,
@@ -45,7 +44,6 @@ exit 0
 
 # BUILD_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with an `@`,

--- a/tests/snapshots/integration__multiline__wrap.snap
+++ b/tests/snapshots/integration__multiline__wrap.snap
@@ -8,7 +8,6 @@ prog -h
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with
@@ -55,7 +54,6 @@ exit 0
 
 # BUILD_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with an `@`,

--- a/tests/snapshots/integration__multiline__wrap2.snap
+++ b/tests/snapshots/integration__multiline__wrap2.snap
@@ -8,7 +8,6 @@ prog foo -h
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with
@@ -55,7 +54,6 @@ exit 0
 
 # BUILD_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with an `@`,

--- a/tests/snapshots/integration__validate__help_version.snap
+++ b/tests/snapshots/integration__validate__help_version.snap
@@ -8,7 +8,6 @@ prog help
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -18,7 +17,6 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -29,7 +27,6 @@ prog --help
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -39,7 +36,6 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -50,7 +46,6 @@ prog -help
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -60,7 +55,6 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -71,7 +65,6 @@ prog -h
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -81,7 +74,6 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -121,5 +113,3 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-
-

--- a/tests/snapshots/integration__validate__help_version_legacy.snap
+++ b/tests/snapshots/integration__validate__help_version_legacy.snap
@@ -8,7 +8,6 @@ prog help
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -18,7 +17,6 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -29,7 +27,6 @@ prog --help
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -39,7 +36,6 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -50,7 +46,6 @@ prog -help
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -60,7 +55,6 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -71,7 +65,6 @@ prog -h
 # OUTPUT
 command cat >&2 <<-'EOF' 
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog
@@ -81,7 +74,6 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-nobody <nobody@example.com>
 Test argc
 
 USAGE: prog

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -5,7 +5,6 @@ fn help_version() {
     let script = r###"
 # @describe Test argc
 # @meta version 1.0.0
-# @meta author nobody <nobody@example.com>
 "###;
     snapshot_multi!(
         script,
@@ -26,7 +25,6 @@ fn help_version_legacy() {
     let script = r###"
 # @describe Test argc
 # @version 1.0.0
-# @author nobody <nobody@example.com>
 "###;
     snapshot_multi!(
         script,


### PR DESCRIPTION
`@meta author <value>`  It's not very useful, so it has been discarded.

If it is truly necessary to use `@meta author`, it can be specified in `@describe`.