### PR TITLE
feat: remove `<name> <version>` header from help text

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -684,9 +684,6 @@ impl Command {
 impl Command {
     pub(crate) fn render_help(&self, wrap_width: Option<usize>) -> String {
         let mut output = vec![];
-        if self.version.is_some() {
-            output.push(self.render_version());
-        }
         if !&self.describe.is_empty() {
             output.push(render_block("", &self.describe, wrap_width));
         }

--- a/tests/snapshots/integration__multiline__nowrap.snap
+++ b/tests/snapshots/integration__multiline__nowrap.snap
@@ -7,7 +7,6 @@ prog -h
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with an `@`,
@@ -43,7 +42,6 @@ EOF
 exit 0
 
 # BUILD_OUTPUT
-prog 1.0.0
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with an `@`,

--- a/tests/snapshots/integration__multiline__wrap.snap
+++ b/tests/snapshots/integration__multiline__wrap.snap
@@ -7,7 +7,6 @@ prog -h
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with
@@ -53,7 +52,6 @@ EOF
 exit 0
 
 # BUILD_OUTPUT
-prog 1.0.0
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with an `@`,

--- a/tests/snapshots/integration__multiline__wrap2.snap
+++ b/tests/snapshots/integration__multiline__wrap2.snap
@@ -7,7 +7,6 @@ prog foo -h
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with
@@ -53,7 +52,6 @@ EOF
 exit 0
 
 # BUILD_OUTPUT
-prog 1.0.0
 How to use multiline help text
 
 Extra lines after the comment tag accepts description, which don't start with an `@`,

--- a/tests/snapshots/integration__validate__help_version.snap
+++ b/tests/snapshots/integration__validate__help_version.snap
@@ -7,7 +7,6 @@ prog help
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -16,7 +15,6 @@ EOF
 exit 0
 
 # RUN_OUTPUT
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -26,7 +24,6 @@ prog --help
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -35,7 +32,6 @@ EOF
 exit 0
 
 # RUN_OUTPUT
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -45,7 +41,6 @@ prog -help
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -54,7 +49,6 @@ EOF
 exit 0
 
 # RUN_OUTPUT
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -64,7 +58,6 @@ prog -h
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -73,7 +66,6 @@ EOF
 exit 0
 
 # RUN_OUTPUT
-prog 1.0.0
 Test argc
 
 USAGE: prog

--- a/tests/snapshots/integration__validate__help_version_exist.snap
+++ b/tests/snapshots/integration__validate__help_version_exist.snap
@@ -7,7 +7,6 @@ prog -h
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 Test argc
 
 USAGE: prog [OPTIONS]
@@ -20,7 +19,6 @@ EOF
 exit 0
 
 # RUN_OUTPUT
-prog 1.0.0
 Test argc
 
 USAGE: prog [OPTIONS]
@@ -40,5 +38,3 @@ exit 0
 
 # RUN_OUTPUT
 prog 1.0.0
-
-

--- a/tests/snapshots/integration__validate__help_version_legacy.snap
+++ b/tests/snapshots/integration__validate__help_version_legacy.snap
@@ -7,7 +7,6 @@ prog help
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -16,7 +15,6 @@ EOF
 exit 0
 
 # RUN_OUTPUT
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -26,7 +24,6 @@ prog --help
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -35,7 +32,6 @@ EOF
 exit 0
 
 # RUN_OUTPUT
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -45,7 +41,6 @@ prog -help
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -54,7 +49,6 @@ EOF
 exit 0
 
 # RUN_OUTPUT
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -64,7 +58,6 @@ prog -h
 
 # OUTPUT
 command cat >&2 <<-'EOF' 
-prog 1.0.0
 Test argc
 
 USAGE: prog
@@ -73,7 +66,6 @@ EOF
 exit 0
 
 # RUN_OUTPUT
-prog 1.0.0
 Test argc
 
 USAGE: prog


### PR DESCRIPTION
The PR removed the `<name> <version>` header from the generated help text.

Old help text
```diff
prog 1.0.0
This is a test CLI

USAGE: prog [OPTIONS] <COMMAND>
```

New help text
```
This is a test CLI

USAGE: prog [OPTIONS] <COMMAND>
```