### PR TITLE
test: add comprehensive CLI tests for argc command branches

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -289,3 +289,461 @@ fn run_argcfile() {
         .stdout(predicates::str::contains("dir1/subdir1/Argcfile.sh"))
         .success();
 }
+
+#[test]
+fn eval_missing_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-eval")
+        .assert()
+        .stdout(predicates::str::contains("Error:"))
+        .success();
+}
+
+#[test]
+fn eval_nonexistent_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-eval")
+        .arg("/nonexistent/path/to/script.sh")
+        .assert()
+        .stdout(predicates::str::contains("Error:"))
+        .stdout(predicates::str::contains("Failed to load script"))
+        .success();
+}
+
+#[test]
+fn eval_invalid_script_path() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-eval")
+        .arg("")
+        .assert()
+        .stdout(predicates::str::contains("Error:"))
+        .success();
+}
+
+#[test]
+fn run_missing_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-run")
+        .assert()
+        .stderr(predicates::str::contains("No script file provided"))
+        .failure();
+}
+
+#[test]
+fn run_nonexistent_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-run")
+        .arg("/nonexistent/path/to/script.sh")
+        .assert()
+        .stderr(predicates::str::contains("Failed to run"))
+        .failure();
+}
+
+#[test]
+fn build_missing_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-build")
+        .assert()
+        .stderr(predicates::str::contains("No script file provided"))
+        .failure();
+}
+
+#[test]
+fn build_nonexistent_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-build")
+        .arg("/nonexistent/path/to/script.sh")
+        .assert()
+        .stderr(predicates::str::contains("Failed to load script"))
+        .failure();
+}
+
+#[test]
+fn build_to_directory() {
+    let path = locate_script("examples/demo.sh");
+    let tmpdir = tmpdir();
+    let outdir = tmpdir.to_path_buf();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-build")
+        .arg(&path)
+        .arg(&outdir)
+        .assert()
+        .success();
+    let outfile = outdir.join("demo.sh");
+    assert!(outfile.exists());
+    let content = std::fs::read_to_string(outfile).unwrap();
+    assert!(content.contains("# ARGC-BUILD"));
+}
+
+#[test]
+fn build_to_file() {
+    let path = locate_script("examples/demo.sh");
+    let tmpdir = tmpdir();
+    let outfile = tmpdir.join("custom.sh");
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-build")
+        .arg(&path)
+        .arg(&outfile)
+        .assert()
+        .success();
+    assert!(outfile.exists());
+    let content = std::fs::read_to_string(outfile).unwrap();
+    assert!(content.contains("# ARGC-BUILD"));
+}
+
+#[test]
+fn mangen_missing_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-mangen")
+        .assert()
+        .stderr(predicates::str::contains("No script file provided"))
+        .failure();
+}
+
+#[test]
+fn mangen_nonexistent_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-mangen")
+        .arg("/nonexistent/path/to/script.sh")
+        .assert()
+        .stderr(predicates::str::contains("Failed to load script"))
+        .failure();
+}
+
+#[test]
+fn mangen_missing_outdir() {
+    let path = locate_script("examples/demo.sh");
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-mangen")
+        .arg(&path)
+        .assert()
+        .stderr(predicates::str::contains("No output dir"))
+        .failure();
+}
+
+#[test]
+fn mangen_invalid_outdir_is_file() {
+    let path = locate_script("examples/demo.sh");
+    let tmpdir = tmpdir();
+    let file_path = tmpdir.child("notadir");
+    file_path.write_str("content").unwrap();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-mangen")
+        .arg(&path)
+        .arg(file_path.path())
+        .assert()
+        .stderr(predicates::str::contains("Not an directory"))
+        .failure();
+}
+
+#[test]
+fn completions_missing_shell() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-completions")
+        .assert()
+        .stderr(predicates::str::contains("Usage: argc --argc-completions"))
+        .failure();
+}
+
+#[test]
+fn completions_invalid_shell() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-completions")
+        .arg("invalid_shell")
+        .assert()
+        .stderr(predicates::str::contains("invalid or missing"))
+        .failure();
+}
+
+#[test]
+fn completions_all_shells() {
+    let shells = ["bash", "zsh", "fish", "powershell", "elvish", "nushell", "xonsh", "tcsh"];
+    for shell in shells {
+        Command::new(assert_cmd::cargo::cargo_bin!())
+            .args(["--argc-completions", shell, "testcmd"])
+            .assert()
+            .stdout(predicates::str::contains("testcmd"))
+            .success();
+    }
+}
+
+#[test]
+fn compgen_missing_args() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-compgen")
+        .assert()
+        .success();
+}
+
+#[test]
+fn compgen_invalid_shell() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .args(["--argc-compgen", "invalid_shell", "", "cmd", ""])
+        .assert()
+        .success();
+}
+
+#[test]
+fn compgen_nonexistent_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .args(["--argc-compgen", "bash", "/nonexistent/script.sh", "prog", ""])
+        .assert()
+        .success();
+}
+
+#[test]
+fn export_missing_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-export")
+        .assert()
+        .stderr(predicates::str::contains("No script file provided"))
+        .failure();
+}
+
+#[test]
+fn export_nonexistent_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-export")
+        .arg("/nonexistent/path/to/script.sh")
+        .assert()
+        .stderr(predicates::str::contains("Failed to load script"))
+        .failure();
+}
+
+#[test]
+fn parallel_missing_args() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-parallel")
+        .assert()
+        .stderr(predicates::str::contains("Usage: argc --argc-parallel"))
+        .failure();
+}
+
+#[test]
+fn parallel_missing_script_args() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-parallel")
+        .arg("script.sh")
+        .assert()
+        .stderr(predicates::str::contains("Usage: argc --argc-parallel"))
+        .failure();
+}
+
+#[test]
+fn parallel_nonexistent_script() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .args(["--argc-parallel", "/nonexistent/script.sh", "cmd"])
+        .assert()
+        .stderr(predicates::str::contains("Failed to load script"))
+        .failure();
+}
+
+#[test]
+fn parallel_non_argc_script() {
+    let tmpdir = tmpdir();
+    let script_file = tmpdir.child("script.sh");
+    script_file.write_str("#!/bin/bash\necho hello\n").unwrap();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .args(["--argc-parallel", script_file.path().to_str().unwrap(), "cmd"])
+        .assert()
+        .stderr(predicates::str::contains("Parallel only available for argc based scripts"))
+        .failure();
+}
+
+#[test]
+fn script_path_not_found() {
+    let tmpdir = tmpdir();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-script-path")
+        .current_dir(tmpdir.path())
+        .assert()
+        .stderr(predicates::str::contains("Argcfile not found"))
+        .failure();
+}
+
+#[test]
+fn unknown_argc_option() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-unknown")
+        .assert()
+        .stderr(predicates::str::contains("Unknown option"))
+        .failure();
+}
+
+#[test]
+fn argcfile_not_found() {
+    let tmpdir = tmpdir();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .current_dir(tmpdir.path())
+        .assert()
+        .stderr(predicates::str::contains("Argcfile not found"))
+        .failure();
+}
+
+#[test]
+fn create_already_exists() {
+    let tmpdir = tmpdir();
+    let script_file = tmpdir.child("Argcfile.sh");
+    script_file.write_str("#!/bin/bash\n").unwrap();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .current_dir(tmpdir.path())
+        .arg("--argc-create")
+        .assert()
+        .stderr(predicates::str::contains("Already exist"))
+        .failure();
+}
+
+#[test]
+fn create_with_custom_env_script_name() {
+    let tmpdir = tmpdir();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .current_dir(tmpdir.path())
+        .env("ARGC_SCRIPT_NAME", "MyTasks")
+        .arg("--argc-create")
+        .assert()
+        .success();
+    assert!(tmpdir.path().join("MyTasks").exists());
+}
+
+#[test]
+fn version_format() {
+    let output = Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-version")
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(stdout.starts_with("argc "));
+    assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn help_contains_all_options() {
+    let output = Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-help")
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let options = [
+        "--argc-eval",
+        "--argc-run",
+        "--argc-create",
+        "--argc-build",
+        "--argc-mangen",
+        "--argc-completions",
+        "--argc-compgen",
+        "--argc-export",
+        "--argc-parallel",
+        "--argc-script-path",
+        "--argc-shell-path",
+        "--argc-help",
+        "--argc-version",
+    ];
+    for option in options {
+        assert!(stdout.contains(option), "Missing option {} in help", option);
+    }
+}
+
+#[test]
+fn run_with_subcommand() {
+    let path = locate_script("examples/demo.sh");
+    let path_env_var = get_path_env_var();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-run")
+        .arg(&path)
+        .args(["upload", "test.txt"])
+        .env("PATH", path_env_var)
+        .assert()
+        .stdout(predicates::str::contains("upload"))
+        .stdout(predicates::str::contains("test.txt"))
+        .success();
+}
+
+#[test]
+fn run_with_help_flag() {
+    let path = locate_script("examples/demo.sh");
+    let path_env_var = get_path_env_var();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-run")
+        .arg(&path)
+        .args(["--help"])
+        .env("PATH", path_env_var)
+        .assert()
+        .stdout(predicates::str::contains("USAGE:"))
+        .success();
+}
+
+#[test]
+fn completions_with_multiple_commands() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .args(["--argc-completions", "bash", "cmd1", "cmd2", "cmd3"])
+        .assert()
+        .stdout(predicates::str::contains("cmd1"))
+        .stdout(predicates::str::contains("cmd2"))
+        .stdout(predicates::str::contains("cmd3"))
+        .success();
+}
+
+#[test]
+fn compgen_argc_internal_commands() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .args(["--argc-compgen", "fish", "", "argc", "--argc-", ""])
+        .assert()
+        .stdout(predicates::str::contains("--argc-eval"))
+        .success();
+}
+
+#[test]
+fn compgen_kind_path() {
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .args([
+            "--argc-compgen",
+            "fish",
+            argc::COMPGEN_KIND_SYMBOL,
+            "path",
+            "",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn export_with_subcommand() {
+    let path = locate_script("examples/demo.sh");
+    let output = Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-export")
+        .arg(&path)
+        .args(["upload"])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(stdout.contains("name"));
+}
+
+#[test]
+fn mangen_creates_directory() {
+    let path = locate_script("examples/demo.sh");
+    let tmpdir = tmpdir();
+    let outdir = tmpdir.join("new_dir");
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-mangen")
+        .arg(&path)
+        .arg(&outdir)
+        .assert()
+        .success();
+    assert!(outdir.exists());
+    assert!(outdir.join("demo.1").exists());
+}
+
+#[test]
+fn build_creates_output_directory() {
+    let path = locate_script("examples/demo.sh");
+    let tmpdir = tmpdir();
+    let outpath = tmpdir.join("new_dir").join("demo.sh");
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .arg("--argc-build")
+        .arg(&path)
+        .arg(&outpath)
+        .assert()
+        .success();
+    assert!(outpath.exists());
+}


### PR DESCRIPTION
## Summary

This PR adds 40 new test cases to improve coverage of CLI branches in main.rs.

**Generated by GLM model.**

## Test Coverage Added

- `--argc-eval`: missing script, nonexistent script, invalid path (3 tests)
- `--argc-run`: missing script, nonexistent script, with subcommand/help (4 tests)
- `--argc-build`: missing script, nonexistent script, output to dir/file (5 tests)
- `--argc-mangen`: missing script, nonexistent script, missing/invalid outdir (5 tests)
- `--argc-completions`: missing shell, invalid shell, all shells (4 tests)
- `--argc-compgen`: missing args, invalid shell, nonexistent script (5 tests)
- `--argc-export`: missing script, nonexistent script, with subcommand (3 tests)
- `--argc-parallel`: missing args, nonexistent script, non-argc script (4 tests)
- `--argc-script-path`: not found error (1 test)
- `--argc-help`/`--argc-version`: format validation (2 tests)
- Other: unknown option, Argcfile not found, create already exists (4 tests)

## Testing Approach

All tests follow existing patterns using assert_cmd, assert_fs, and predicates.

## Files Changed

- `tests/cli.rs`: +458 lines (40 new test functions)
