### PR TITLE
feat: support external subcommand execution and completion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ application = [
     "path-absolutize"
 ]
 native-runtime = ["which"]
-eval = []
+eval = ["natord"]
 eval-bash = ["eval"]
 build = []
 mangen = ["roff"]

--- a/docs/external-subcommands.md
+++ b/docs/external-subcommands.md
@@ -1,0 +1,150 @@
+# External Subcommands
+
+External subcommands are standalone scripts named `<main-command>-<sub-command>[.ext]` that live in the same directory as the main script. When enabled, they can be invoked as if they were built-in subcommands.
+
+## Enable
+
+Add `@meta external-subcommands` to the root of your argc script:
+
+```sh
+# @describe A CLI with external subcommands
+# @meta external-subcommands
+
+# @cmd A built-in subcommand
+builtin() {
+    echo "builtin cmd"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"
+```
+
+## Convention
+
+External subcommands follow the naming pattern `<main-command>-<sub-command>.sh`:
+
+| Main script | External subcommand | Invocation |
+|-------------|-------------------|------------|
+| `prog.sh` | `prog-foo.sh` | `prog foo ...` |
+| `prog.sh` | `prog-bar.sh` | `prog bar ...` |
+| `Argcfile.sh` | `Argcfile-build.sh` | `argc build ...` |
+
+- The extension (`.sh`) must match the main script
+- External scripts are regular argc scripts — they must define their own args/flags and end with `eval "$(argc --argc-eval "$0" "$@")"`
+- Internal subcommands take priority over external ones
+- Only the immediate parent directory of the main script is scanned
+
+## Example
+
+### Main script: `external.sh`
+
+```sh
+# @describe A CLI with external subcommands
+# @meta external-subcommands
+
+# @cmd A built-in subcommand
+builtin() {
+    echo "builtin cmd"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"
+```
+
+### External subcommand: `external-foo.sh`
+
+```sh
+# @describe An external subcommand "foo"
+
+# @arg message!   Message to echo
+main() {
+    echo "external-foo: $argc_message"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"
+```
+
+### External subcommand with flags: `external-bar.sh`
+
+```sh
+# @describe An external subcommand "bar" with options
+
+# @flag   -v --verbose   Enable verbose output
+# @arg    message!       Message to echo
+main() {
+    echo "external-bar: $argc_message"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"
+```
+
+### Usage
+
+```
+$ external --help
+Test external subcommands
+
+USAGE: external <COMMAND>
+
+COMMANDS:
+  builtin  A built-in subcommand [aliases: b]
+
+EXTERNAL COMMANDS:
+  bar  An external subcommand "bar" with options
+  foo  An external subcommand "foo"
+
+$ external foo hello
+external-foo: hello
+
+$ external bar -v hey
+verbose mode
+external-bar: hey
+
+$ external builtin hello
+builtin: hello
+```
+
+## Completion
+
+External subcommand names and their descriptions appear in tab-completion results, just like internal subcommands:
+
+```
+$ external <TAB>
+builtin  bar  foo  help
+$ external f<TAB>
+$ external foo <TAB>
+```
+
+## How It Works
+
+1. When `@meta external-subcommands` is set, argc scans the script's directory for files matching `<script-name>-*.sh`
+2. Each matching file is registered as an external subcommand
+3. During argument matching, if an arg doesn't match any internal subcommand, it's checked against the external list
+4. If matched, the eval output generates `export ARGC_PARENT_ARGS=...` and `bash <external-script> <remaining-args>` as the last statement
+
+## `ARGC_PARENT_ARGS`
+
+When an external subcommand is dispatched, argc exports the `ARGC_PARENT_ARGS` environment variable containing the parent command and its flags (the args before the subcommand name). This allows external scripts to re-invoke the parent command with the original global options preserved.
+
+For example, with `git --git-dir=<path> mytool ...`, the external subcommand `mytool` receives:
+
+```sh
+export ARGC_PARENT_ARGS="git --git-dir=<path>"
+bash examples/git-mytool.sh ...
+```
+
+The external script can define a helper function to call back to the parent:
+
+```sh
+_git() {
+  eval "$ARGC_PARENT_ARGS" "$@"
+}
+
+# Usage:
+_git log --oneline
+```
+
+## Limitations
+
+- **`--argc-build` does NOT support external subcommands** — the build feature compiles a single script into a standalone file and cannot include external scripts
+- External scripts must be in the same directory as the main script (no recursive search)
+- Only single-level external subcommands are supported (`prog foo` works, `prog foo bar` does not resolve `prog-foo-bar`)
+- External subcommand names starting with `-` are ignored to avoid flag-name conflicts

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -181,6 +181,7 @@ Adds metadata.
 | `@meta man-section <1-8>`        | root   | Override the section for the man page, defaulting to 1.              |
 | `@meta inherit-flag-options`     | root   | Subcommands will inherit the flags/options from their parent.        |
 | `@meta combine-shorts`           | root   | Short flags/options can be combined, e.g. `prog -xf => prog -x -f `. |
+| `@meta external-subcommands`     | root   | Enable external subcommands: scripts named `<cmd>-<name>.sh` in the same directory. |
 | `@meta symbol <param>`           | any    | Define a symbolic parameter, e.g. `+toolchain`, `@argument-file`.    |
 
 

--- a/examples/external-bar.sh
+++ b/examples/external-bar.sh
@@ -1,0 +1,9 @@
+# @describe An external subcommand "bar" with options
+
+# @flag   -v --verbose   Enable verbose output
+# @arg    message!       Message to echo
+main() {
+    echo "external-bar: $argc_message"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"

--- a/examples/external-foo.sh
+++ b/examples/external-foo.sh
@@ -1,0 +1,8 @@
+# @describe An external subcommand "foo"
+
+# @arg message!   Message to echo
+main() {
+    echo "external-foo: $argc_message"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"

--- a/examples/external.sh
+++ b/examples/external.sh
@@ -1,0 +1,11 @@
+# @describe Test external subcommands
+# @meta external-subcommands
+
+# @cmd A built-in subcommand
+# @alias b
+# @arg message!   Message to echo
+builtin() {
+    echo "builtin: $argc_message"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"

--- a/src/argc_value.rs
+++ b/src/argc_value.rs
@@ -23,6 +23,7 @@ pub enum ArgcValue {
     RequireTools(Vec<String>),
     CommandFn(String),
     ParamFn(String),
+    ExternalSubcommand(String, Vec<String>, usize),
     Error((String, i32)),
 }
 
@@ -34,6 +35,7 @@ impl ArgcValue {
         let mut exit = false;
         let mut positional_args = vec![];
         let mut require_tools = vec![];
+        let mut exist_external_subcommand = false;
         let (mut before_hook, mut after_hook) = (false, false);
         for value in values {
             match value {
@@ -131,10 +133,34 @@ impl ArgcValue {
                     }
                     exit = true;
                 }
+                ArgcValue::ExternalSubcommand(script_path, args, subcommand_args_index) => {
+                    let parent_args = &args[0..*subcommand_args_index];
+                    let remaining_args = &args[*subcommand_args_index + 1..];
+                    let parent_cmd = parent_args
+                        .iter()
+                        .map(|v| escape_shell_words(v))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let cmd = std::iter::once("bash".to_string())
+                        .chain(std::iter::once(script_path.clone()))
+                        .chain(remaining_args.iter().cloned())
+                        .map(|v| escape_shell_words(&v))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    last = format!(
+                        "export ARGC_PARENT_ARGS={}\n{cmd}",
+                        escape_shell_words(&parent_cmd)
+                    );
+                    exist_external_subcommand = true;
+                }
                 ArgcValue::Error((error, exit)) => {
                     return format!("command cat >&2 <<-'EOF' \n{error}\nEOF\nexit {exit}")
                 }
             }
+        }
+
+        if exist_external_subcommand {
+            return last;
         }
 
         list.push(format!(

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -26,6 +26,13 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+#[derive(Debug, Clone)]
+pub(crate) struct ExternalSubcommandInfo {
+    pub name: String,
+    pub description: String,
+    pub path: String,
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct Command {
     pub(crate) name: Option<String>,
@@ -51,6 +58,7 @@ pub(crate) struct Command {
     pub(crate) require_tools: IndexSet<String>,
     pub(crate) help_flags: Vec<&'static str>,
     pub(crate) version_flags: Vec<&'static str>,
+    pub(crate) external_subcommands: Vec<ExternalSubcommandInfo>,
 }
 
 impl Command {
@@ -701,6 +709,7 @@ impl Command {
         output.extend(self.render_positionals(wrap_width));
         output.extend(self.render_flag_options(wrap_width));
         output.extend(self.render_subcommands(wrap_width));
+        output.extend(self.render_external_subcommands(wrap_width));
         output.extend(self.render_envs(wrap_width));
         if output.is_empty() {
             return "\n".to_string();
@@ -835,6 +844,26 @@ impl Command {
         output
     }
 
+    fn render_external_subcommands(&self, wrap_width: Option<usize>) -> Vec<String> {
+        let mut output = vec![];
+        if self.external_subcommands.is_empty() {
+            return output;
+        }
+        let mut value_size = 0;
+        let list: Vec<_> = self
+            .external_subcommands
+            .iter()
+            .map(|info| {
+                value_size = value_size.max(info.name.len());
+                (info.name.clone(), info.description.clone())
+            })
+            .collect();
+        value_size += 2;
+        output.push("EXTERNAL COMMANDS:".to_string());
+        render_list(&mut output, list, value_size, wrap_width);
+        output
+    }
+
     fn render_subcommand_describe(&self) -> String {
         let mut output = self.describe_oneline().to_string();
         if let Some((aliases, _)) = &self.aliases {
@@ -906,6 +935,74 @@ fn update_parent_cmd(parent: &mut Command) -> Result<()> {
 
 fn sanitize_cmd_name(name: &str) -> String {
     name.trim_end_matches('_').to_string()
+}
+
+#[cfg(any(feature = "eval", feature = "compgen"))]
+pub(crate) fn collect_external_subcommands<T: Runtime>(
+    runtime: T,
+    script_path: &str,
+) -> Vec<ExternalSubcommandInfo> {
+    let dir = match runtime.parent_path(script_path) {
+        Some(d) => d,
+        None => return vec![],
+    };
+    let script_name = match script_path.rsplit(['/', '\\']).next() {
+        Some(name) => name.to_string(),
+        None => return vec![],
+    };
+    let (base_name, ext) = match script_name.rsplit_once('.') {
+        Some((stem, "sh")) => (stem.to_string(), ".sh".to_string()),
+        _ => (script_name, String::new()),
+    };
+    let prefix = format!("{base_name}-");
+    let mut result = vec![];
+    if let Some(entries) = runtime.read_dir(&dir) {
+        for file_name in entries {
+            if !file_name.starts_with(&prefix) {
+                continue;
+            }
+            if !ext.is_empty() && !file_name.ends_with(&ext) {
+                continue;
+            }
+            let sub_name = if ext.is_empty() {
+                file_name[prefix.len()..].to_string()
+            } else {
+                file_name[prefix.len()..]
+                    .strip_suffix(".sh")
+                    .unwrap_or(&file_name[prefix.len()..])
+                    .to_string()
+            };
+            if sub_name.starts_with('-') {
+                continue;
+            }
+            let full_path = runtime.join_path(&dir, &[&file_name]);
+            let description = runtime
+                .read_to_string(&full_path)
+                .map(|content| extract_description(&content))
+                .unwrap_or_default();
+            result.push(ExternalSubcommandInfo {
+                name: sub_name,
+                description,
+                path: full_path,
+            });
+        }
+    }
+    result.sort_by(|a, b| natord::compare_ignore_case(&a.name, &b.name));
+    result
+}
+
+#[cfg(any(feature = "eval", feature = "compgen"))]
+fn extract_description(content: &str) -> String {
+    for line in content.lines() {
+        match crate::parser::parse_line(line) {
+            Ok((_, Some(Some(EventData::Describe(value))))) => return value,
+            Ok((_, Some(Some(EventData::Cmd(_))))) | Ok((_, Some(Some(EventData::Func(_))))) => {
+                break;
+            }
+            _ => {}
+        }
+    }
+    String::new()
 }
 
 fn render_list(

--- a/src/compgen.rs
+++ b/src/compgen.rs
@@ -1,10 +1,10 @@
-use crate::command::Command;
+use crate::command::{collect_external_subcommands, Command};
 use crate::matcher::Matcher;
 use crate::runtime::Runtime;
 use crate::utils::{is_quote_char, is_windows_path, unbalance_quote};
 use crate::Shell;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -35,7 +35,7 @@ pub fn compgen<T: Runtime>(
             (last_arg.to_string(), None)
         }
     };
-    let cmd = if script_path == COMPGEN_KIND_SYMBOL {
+    let mut cmd = if script_path == COMPGEN_KIND_SYMBOL {
         let comp_kind = &args[0];
         let script_content = format!(
             r#"# @arg args~[`{comp_kind}`]
@@ -60,7 +60,37 @@ pub fn compgen<T: Runtime>(
             })
             .collect()
     };
+
+    // Collect external subcommands for Matcher-based detection
+    if script_path != COMPGEN_KIND_SYMBOL
+        && !script_path.is_empty()
+        && cmd.has_metadata(crate::utils::META_EXTERNAL_SUBCOMMANDS)
+    {
+        cmd.external_subcommands = collect_external_subcommands(runtime, script_path);
+    }
     let matcher = Matcher::new(runtime, &cmd, &new_args, true);
+    // Check for external subcommand detection in Matcher
+    if let Some(detected_name) = matcher.detected_external_subcommand {
+        if let Some(info) = cmd
+            .external_subcommands
+            .iter()
+            .find(|e| e.name == detected_name)
+        {
+            let content = runtime
+                .read_to_string(&info.path)
+                .ok_or_else(|| anyhow!("Failed to read external script at {}", info.path))?;
+            let ext_name = info
+                .path
+                .rsplit(['/', '\\'])
+                .next()
+                .and_then(|n| n.strip_suffix(".sh").or(Some(n)))
+                .unwrap_or("argc");
+            let ext_args: Vec<String> = std::iter::once(ext_name.to_string())
+                .chain(matcher.detected_external_subcommand_args.iter().cloned())
+                .collect();
+            return compgen(runtime, shell, &info.path, &content, &ext_args, no_color);
+        }
+    }
     let compgen_values = matcher.compgen(shell);
     let mut default_nospace = unbalance.is_some();
     let mut prefix = unbalance.map(|v| v.to_string()).unwrap_or_default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,11 @@ pub fn eval<T: Runtime>(
     wrap_width: Option<usize>,
 ) -> Result<Vec<ArgcValue>> {
     let mut cmd = command::Command::new(script_content, &args[0])?;
+    if let Some(p) = script_path {
+        if cmd.has_metadata(crate::utils::META_EXTERNAL_SUBCOMMANDS) {
+            cmd.external_subcommands = command::collect_external_subcommands(runtime, p);
+        }
+    }
     cmd.eval(runtime, args, script_path, wrap_width)
 }
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     argc_value::ArgcValue,
-    command::{Command, SymbolParam},
+    command::{Command, ExternalSubcommandInfo, SymbolParam},
     param::{ChoiceValue, FlagOptionParam, Param, ParamData, PositionalParam},
     runtime::Runtime,
     utils::{argc_var_name, is_true_value, META_COMBINE_SHORTS},
@@ -19,7 +19,7 @@ use crate::{
 use either::Either;
 use indexmap::{IndexMap, IndexSet};
 
-pub(crate) struct Matcher<'a, 'b, T> {
+pub(crate) struct Matcher<'a: 'b, 'b, T> {
     runtime: T,
     cmds: Vec<&'a Command>,
     cmd_arg_indexes: Vec<usize>,
@@ -35,6 +35,8 @@ pub(crate) struct Matcher<'a, 'b, T> {
     wrap_width: Option<usize>,
     split_last_arg_at: Option<usize>,
     comp_option: Option<&'a str>,
+    pub(crate) detected_external_subcommand: Option<&'b str>,
+    pub(crate) detected_external_subcommand_args: &'b [String],
 }
 
 pub(crate) type FlagOptionArg<'a, 'b> = (&'b str, Vec<&'b str>, Option<&'a str>); // key, values, param_name
@@ -73,7 +75,7 @@ pub(crate) enum MatchError {
     NoFlagValue(usize, String),
 }
 
-impl<'a, 'b, T: Runtime> Matcher<'a, 'b, T> {
+impl<'a: 'b, 'b, T: Runtime> Matcher<'a, 'b, T> {
     pub(crate) fn new(
         runtime: T,
         root_cmd: &'a Command,
@@ -93,6 +95,8 @@ impl<'a, 'b, T: Runtime> Matcher<'a, 'b, T> {
         let mut arg_comp = ArgComp::Any;
         let mut choice_fns = HashSet::new();
         let mut comp_option = None;
+        let mut detected_external_subcommand = None;
+        let mut detected_external_subcommand_args: &[String] = &[];
         let args_len = args.len();
         if root_cmd.delegated() {
             positional_args = args.iter().skip(1).map(|v| v.as_str()).collect();
@@ -302,6 +306,19 @@ impl<'a, 'b, T: Runtime> Matcher<'a, 'b, T> {
                         split_last_arg_at = Some(1);
                     }
                 } else {
+                    // External subcommand detection
+                    if !root_cmd.external_subcommands.is_empty()
+                        && positional_args.is_empty()
+                        && !(compgen && is_last_arg)
+                    {
+                        if let Some(info) =
+                            root_cmd.external_subcommands.iter().find(|e| e.name == arg)
+                        {
+                            detected_external_subcommand = Some(info.name.as_str());
+                            detected_external_subcommand_args = &args[arg_index + 1..];
+                            break;
+                        }
+                    }
                     let mut target_cmd = cmd;
                     if positional_args.is_empty() && !(compgen && is_last_arg) {
                         if let Some(subcmd) = cmd.find_default_subcommand() {
@@ -380,6 +397,8 @@ impl<'a, 'b, T: Runtime> Matcher<'a, 'b, T> {
             split_last_arg_at,
             comp_option,
             envs,
+            detected_external_subcommand,
+            detected_external_subcommand_args,
         }
     }
 
@@ -393,6 +412,21 @@ impl<'a, 'b, T: Runtime> Matcher<'a, 'b, T> {
 
     #[cfg(feature = "eval")]
     pub(crate) fn to_arg_values(&self) -> Vec<ArgcValue> {
+        if let Some(detected_name) = self.detected_external_subcommand {
+            let script_path = self.cmds[0]
+                .external_subcommands
+                .iter()
+                .find(|e| e.name == detected_name)
+                .map(|e| e.path.clone())
+                .unwrap_or_default();
+            let remaining_len = self.detected_external_subcommand_args.len();
+            let subcommand_args_index = self.args.len() - remaining_len - 1;
+            return vec![ArgcValue::ExternalSubcommand(
+                script_path,
+                self.args.to_vec(),
+                subcommand_args_index,
+            )];
+        }
         let bind_envs = self.build_bind_envs();
         if let Some(err) = self.validate(&bind_envs) {
             return vec![ArgcValue::Error(self.stringify_match_error(&err))];
@@ -467,13 +501,21 @@ impl<'a, 'b, T: Runtime> Matcher<'a, 'b, T> {
         let mut output = match &self.arg_comp {
             ArgComp::FlagOrOption => {
                 let mut output = self.comp_flag_options(false);
-                output.extend(comp_subcomands(last_cmd, true));
+                output.extend(comp_subcomands(
+                    last_cmd,
+                    true,
+                    &self.cmds[0].external_subcommands,
+                ));
                 output
             }
             ArgComp::FlagOrOptionCombine(value) => {
                 let mut output: Vec<CompItem> = vec![];
                 if value.len() == 2 && &self.args[self.cmd_arg_indexes[level]] == value {
-                    output.extend(comp_subcomands(self.cmds[level - 1], true));
+                    output.extend(comp_subcomands(
+                        self.cmds[level - 1],
+                        true,
+                        &self.cmds[0].external_subcommands,
+                    ));
                 }
                 output.extend(self.comp_flag_options(true).iter().filter_map(
                     |(v, description, nospace, comp_color)| {
@@ -504,10 +546,15 @@ impl<'a, 'b, T: Runtime> Matcher<'a, 'b, T> {
             }
             ArgComp::CommandOrPositional => {
                 if self.positional_args.len() == 2 && self.positional_args[0] == "help" {
-                    return comp_subcomands(last_cmd, false);
+                    return comp_subcomands(last_cmd, false, &self.cmds[0].external_subcommands);
                 }
                 let values = self.match_positionals();
-                comp_subcommands_positional(last_cmd, &values, self.positional_args.len() < 2)
+                comp_subcommands_positional(
+                    last_cmd,
+                    &values,
+                    self.positional_args.len() < 2,
+                    &self.cmds[0].external_subcommands,
+                )
             }
             ArgComp::OptionValue(name, index) => {
                 if let Some(param) = last_cmd.flag_option_params.iter().find(|v| v.id() == name) {
@@ -519,10 +566,15 @@ impl<'a, 'b, T: Runtime> Matcher<'a, 'b, T> {
             ArgComp::Symbol(ch) => comp_symbol(last_cmd, *ch),
             ArgComp::Any => {
                 if self.positional_args.len() == 2 && self.positional_args[0] == "help" {
-                    return comp_subcomands(last_cmd, false);
+                    return comp_subcomands(last_cmd, false, &self.cmds[0].external_subcommands);
                 }
                 let values = self.match_positionals();
-                comp_subcommands_positional(last_cmd, &values, self.positional_args.len() < 2)
+                comp_subcommands_positional(
+                    last_cmd,
+                    &values,
+                    self.positional_args.len() < 2,
+                    &self.cmds[0].external_subcommands,
+                )
             }
         };
         if output.is_empty()
@@ -990,7 +1042,13 @@ impl<'a, 'b, T: Runtime> Matcher<'a, 'b, T> {
                 exit = 1;
                 let cmd = self.last_cmd();
                 let cmd_str = cmd.cmd_paths().join("-");
-                let names = cmd.list_subcommand_names().join(", ");
+                let mut names: Vec<String> = cmd.list_subcommand_names();
+                for info in self.cmds[0].external_subcommands.iter() {
+                    if !names.contains(&info.name) {
+                        names.push(info.name.clone());
+                    }
+                }
+                let names = names.join(", ");
                 let details = match arg {
                     Some(arg) => format!("but '{arg}' is not one of them"),
                     None => "but one was not provided".to_string(),
@@ -1327,10 +1385,11 @@ fn comp_subcommands_positional(
     cmd: &Command,
     values: &[Vec<&str>],
     with_subcmd: bool,
+    external_subcommands: &[ExternalSubcommandInfo],
 ) -> Vec<CompItem> {
     let mut output = vec![];
     if with_subcmd {
-        output.extend(comp_subcomands(cmd, false));
+        output.extend(comp_subcomands(cmd, false, external_subcommands));
 
         // default subcommand
         if let Some(subcmd) = cmd.find_default_subcommand() {
@@ -1348,7 +1407,11 @@ fn comp_subcommands_positional(
 }
 
 #[cfg(feature = "compgen")]
-fn comp_subcomands(cmd: &Command, flag: bool) -> Vec<CompItem> {
+fn comp_subcomands(
+    cmd: &Command,
+    flag: bool,
+    external_subcommands: &[ExternalSubcommandInfo],
+) -> Vec<CompItem> {
     let mut output = vec![];
     let mut has_help_subcmd = false;
     let mut describe_help_subcmd = false;
@@ -1368,6 +1431,20 @@ fn comp_subcomands(cmd: &Command, flag: bool) -> Vec<CompItem> {
                     describe_help_subcmd = true
                 }
                 output.push((v, describe.to_string(), false, CompColor::of_command()))
+            }
+        }
+    }
+    for info in external_subcommands {
+        output.push((
+            info.name.clone(),
+            info.description.clone(),
+            false,
+            CompColor::of_command(),
+        ));
+        if !flag {
+            has_help_subcmd = true;
+            if !info.description.is_empty() {
+                describe_help_subcmd = true;
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -117,7 +117,7 @@ pub(crate) fn parse_symbol(input: &str) -> Option<(char, &str, Option<&str>)> {
     parse_symbol_data(input).map(|(_, v)| v).ok()
 }
 
-fn parse_line(line: &str) -> nom::IResult<&str, Option<Option<EventData>>> {
+pub(crate) fn parse_line(line: &str) -> nom::IResult<&str, Option<Option<EventData>>> {
     alt((map(alt((parse_tag, parse_fn)), Some), success(None))).parse(line)
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,6 +13,7 @@ pub(crate) const META_DEFAULT_SUBCOMMAND: &str = "default-subcommand";
 pub(crate) const META_INHERIT_FLAG_OPTIONS: &str = "inherit-flag-options";
 pub(crate) const META_SYMBOL: &str = "symbol";
 pub(crate) const META_COMBINE_SHORTS: &str = "combine-shorts";
+pub(crate) const META_EXTERNAL_SUBCOMMANDS: &str = "external-subcommands";
 pub(crate) const META_MAN_SECTION: &str = "man-section";
 pub(crate) const META_REQUIRE_TOOLS: &str = "require-tools";
 

--- a/tests/external_subcommands.rs
+++ b/tests/external_subcommands.rs
@@ -1,0 +1,125 @@
+use predicates::prelude::*;
+
+fn bin() -> assert_cmd::Command {
+    assert_cmd::Command::new(assert_cmd::cargo::cargo_bin!())
+}
+
+fn script_path() -> String {
+    crate::fixtures::locate_script("examples/external.sh")
+}
+
+#[test]
+fn help_shows_external_commands() {
+    bin()
+        .arg("--argc-eval")
+        .arg(script_path())
+        .arg("--help")
+        .assert()
+        .stdout(predicate::str::contains("EXTERNAL COMMANDS:"))
+        .stdout(predicate::str::contains("bar"))
+        .stdout(predicate::str::contains("foo"))
+        .stdout(predicate::str::contains(
+            r#"An external subcommand "bar" with options"#,
+        ))
+        .stdout(predicate::str::contains(r#"An external subcommand "foo""#))
+        .success();
+}
+
+#[test]
+fn internal_subcommand_still_works() {
+    bin()
+        .arg("--argc-eval")
+        .arg(script_path())
+        .arg("builtin")
+        .arg("hello")
+        .assert()
+        .stdout(predicate::str::contains("argc__fn=builtin"))
+        .success();
+}
+
+#[test]
+fn external_external_subcommand_generates_bash_call() {
+    bin()
+        .arg("--argc-eval")
+        .arg(script_path())
+        .arg("foo")
+        .arg("hello")
+        .assert()
+        .stdout(predicate::str::contains("export ARGC_PARENT_ARGS=external"))
+        .stdout(predicate::str::contains("bash"))
+        .stdout(predicate::str::contains("external-foo.sh"))
+        .stdout(predicate::str::contains("hello"))
+        .success();
+}
+
+#[test]
+fn external_external_subcommand_with_flags_generates_bash_call() {
+    bin()
+        .arg("--argc-eval")
+        .arg(script_path())
+        .arg("bar")
+        .arg("-v")
+        .arg("hey")
+        .assert()
+        .stdout(predicate::str::contains("bash"))
+        .stdout(predicate::str::contains("external-bar.sh"))
+        .stdout(predicate::str::contains("-v"))
+        .stdout(predicate::str::contains("hey"))
+        .success();
+}
+
+#[test]
+fn compgen_include_external_subcommands() {
+    bin()
+        .arg("--argc-compgen")
+        .arg("generic")
+        .arg(script_path())
+        .arg("external")
+        .arg("")
+        .assert()
+        .stdout(predicate::str::contains("builtin"))
+        .stdout(predicate::str::contains("foo"))
+        .stdout(predicate::str::contains("bar"))
+        .stdout(predicate::str::contains("help"))
+        .success();
+}
+
+#[test]
+fn compgen_show_external_subcommands_after_partial() {
+    bin()
+        .arg("--argc-compgen")
+        .arg("generic")
+        .arg(script_path())
+        .arg("external")
+        .arg("f")
+        .assert()
+        .stdout(predicate::str::contains("foo"))
+        .success();
+}
+
+#[test]
+fn compgen_show_external_subcommand_flags() {
+    bin()
+        .arg("--argc-compgen")
+        .arg("generic")
+        .arg(script_path())
+        .arg("external")
+        .arg("bar")
+        .arg("--")
+        .assert()
+        .stdout(predicate::str::contains("verbose"))
+        .success();
+}
+
+#[test]
+fn invalid_subcommand_error_includes_external() {
+    bin()
+        .arg("--argc-eval")
+        .arg(script_path())
+        .arg("abc")
+        .assert()
+        .stdout(predicate::str::contains(
+            "subcommands: builtin, b, bar, foo",
+        ))
+        .success();
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -23,3 +23,5 @@ mod multiline;
 mod param_fn;
 mod spec;
 mod validate;
+
+mod external_subcommands;


### PR DESCRIPTION
Add support for **external subcommands** — standalone scripts named `<main-command>-<subcommand>[.ext]` that live in the same directory as the main script. When enabled via `# @meta external-subcommands`, they can be invoked and auto-completed as if they were regular built-in subcommands.

## Key features

- **`@meta external-subcommands`** — opt-in flag on the root command to enable scanning
- **Automatic discovery** — scans the script directory for files matching `<script-name>-*.sh`, extracts descriptions from `# @describe` annotations
- **Execution** — when no internal subcommand matches, argc generates `bash <external-script> <remaining-args>` as the final eval statement
- **`ARGC_PARENT_ARGS`** — exports parent args (flags before the subcommand name) so external scripts can re-invoke the parent with `eval "$ARGC_PARENT_ARGS" "$@"`
- **Completion** — external subcommand names and descriptions appear in tab-completion results, just like internal ones
- **Help text** — external subcommands rendered as an `EXTERNAL COMMANDS:` section in `--help` output
- **Error messages** — invalid subcommand errors include external subcommand names in the suggestions list

## Example

See [examples](https://github.com/sigoden/argc/tree/main/examples)/{external.sh, external-foo.sh, external-bar.sh}

```
$ external --help
Test external subcommands

USAGE: external <COMMAND>

COMMANDS:
  builtin  A built-in subcommand [aliases: b]

EXTERNAL COMMANDS:
  bar  An external subcommand "bar" with options
  foo  An external subcommand "foo"

$ external foo hello
external-foo: hello

$ external bar -v hey
verbose mode
external-bar: hey

$ external builtin hello
builtin: hello
```

## Limitations

- `--argc-build` does not support external subcommands
- Only single-level subcommands (`prog foo`, not `prog foo bar`)
- Only the immediate parent directory is scanned
