### PR TITLE
fix: resolve dotenv panic, wrong error message, false-positive value …

### DIFF
--- a/src/argc_value.rs
+++ b/src/argc_value.rs
@@ -69,7 +69,8 @@ impl ArgcValue {
                             .map(|x| escape_shell_words(x))
                             .collect::<Vec<String>>()
                             .join("|");
-                        format!(r#"{var_name}["{k}"]={v}"#)
+                        let k = escape_shell_words(k);
+                        format!(r#"{var_name}[{k}]={v}"#)
                     }));
                 }
                 ArgcValue::PositionalSingle(id, value) => {

--- a/src/build.rs
+++ b/src/build.rs
@@ -592,7 +592,7 @@ fn build_positionals(cmd: &Command) -> String {
             let required = if param.required() {
                 format!(
                     r#"
-            _argc_die "error: the required environments \`{render_value}\` were not provided""#
+            _argc_die "error: the required arguments \`{render_value}\` were not provided""#
                 )
             } else {
                 String::new()

--- a/src/compgen.rs
+++ b/src/compgen.rs
@@ -602,10 +602,14 @@ impl ArgcPathValue {
             }
             if !is_dir
                 && !self.exts.is_empty()
-                && self
-                    .exts
-                    .iter()
-                    .all(|v| !file_name.to_lowercase().ends_with(v))
+                && self.exts.iter().all(|v| {
+                    let ext = if v.starts_with('.') {
+                        v.to_string()
+                    } else {
+                        format!(".{v}")
+                    };
+                    !file_name.to_lowercase().ends_with(&ext)
+                })
             {
                 continue;
             }
@@ -749,12 +753,14 @@ fn convert_arg_value(value: &str) -> Option<ArgcPathValue> {
     } else if ["path", "file", "arg", "any"]
         .iter()
         .any(|v| value.contains(v))
+    // Here need to be contains, becuase user may set output-file or something like that
     {
         Some(ArgcPathValue {
             is_dir: false,
             exts: vec![],
         })
     } else if value.contains("dir") || value.contains("folder") {
+        // Same as above, need to be contains
         Some(ArgcPathValue {
             is_dir: true,
             exts: vec![],

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -232,8 +232,13 @@ impl<'a: 'b, 'b, T: Runtime> Matcher<'a, 'b, T> {
                                 arg_comp = ArgComp::FlagOrOptionCombine(arg.to_string());
                             }
                         } else {
-                            let name = arr.pop().and_then(|v| v.2).unwrap();
-                            let param = current_cmd.find_flag_option(name).unwrap();
+                            let name = arr
+                                .pop()
+                                .and_then(|v| v.2)
+                                .expect("combine_shorts: expected flag/option name");
+                            let param = current_cmd
+                                .find_flag_option(name)
+                                .expect("combine_shorts: expected matching param");
                             add_param_choice_fn(&mut choice_fns, param);
                             flag_option_args[cmd_level].extend(arr);
                             match_flag_option(
@@ -1496,7 +1501,12 @@ fn comp_flag_option(param: &FlagOptionParam, index: usize) -> Vec<CompItem> {
         .notations()
         .get(index)
         .map(|v| v.as_str())
-        .unwrap_or_else(|| param.notations().last().unwrap());
+        .unwrap_or_else(|| {
+            param
+                .notations()
+                .last()
+                .expect("Notaion always has at least one")
+        });
     comp_param(param.describe_oneline(), value_name, param.data())
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -725,6 +725,12 @@ fn parse_bind_env(input: &str) -> nom::IResult<&str, Option<String>> {
 }
 
 fn notation_text(input: &str, balances: usize) -> nom::IResult<&str, usize> {
+    if balances > 128 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
     let (i1, c1) = anychar(input)?;
     match c1 {
         '<' => {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -67,8 +67,9 @@ where
             if let Some((key, value)) = line.split_once('=') {
                 let env_name = key.trim().to_string();
                 let env_value = value.trim().to_string();
-                let env_value = if (env_value.starts_with('"') && env_value.ends_with('"'))
-                    || (env_value.starts_with('\'') && env_value.ends_with('\''))
+                let env_value = if env_value.len() >= 2
+                    && ((env_value.starts_with('"') && env_value.ends_with('"'))
+                        || (env_value.starts_with('\'') && env_value.ends_with('\'')))
                 {
                     &env_value[1..env_value.len() - 1]
                 } else {

--- a/tests/snapshots/integration__bind_env__bind_env_cmd_three_required_args_err.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_cmd_three_required_args_err.snap
@@ -9,4 +9,4 @@ error: the following required arguments were not provided:
 
 
 # BUILD_OUTPUT
-error: the required environments `<VAL3>` were not provided
+error: the required arguments `<VAL3>` were not provided

--- a/tests/snapshots/integration__spec__option_prefixed.snap
+++ b/tests/snapshots/integration__spec__option_prefixed.snap
@@ -7,10 +7,10 @@ prog -o1 -Dv1=foo -Dv2 bar
 
 # OUTPUT
 declare -A argc_o
-argc_o["1"]=1
+argc_o[1]=1
 declare -A argc_D
-argc_D["v1"]=foo
-argc_D["v2"]=bar
+argc_D[v1]=foo
+argc_D[v2]=bar
 argc__args=( prog -o1 '-Dv1=foo' -Dv2 bar )
 argc__positionals=(  )
 

--- a/tests/snapshots/integration__validate__arg_missing.snap
+++ b/tests/snapshots/integration__validate__arg_missing.snap
@@ -13,4 +13,4 @@ EOF
 exit 1
 
 # BUILD_OUTPUT
-error: the required environments `<VAL>...` were not provided
+error: the required arguments `<VAL>...` were not provided

--- a/tests/snapshots/integration__validate__param_missing.snap
+++ b/tests/snapshots/integration__validate__param_missing.snap
@@ -13,4 +13,4 @@ EOF
 exit 1
 
 # BUILD_OUTPUT
-error: the required environments `<VAL>` were not provided
+error: the required arguments `<VAL>` were not provided


### PR DESCRIPTION
…classification, and 6 other bugs

- H1: guard dotenv value slice against single-char value panic
- H2: fix error message 'environments' -> 'arguments' for positionals
- M1: prepend dot prefix for file extension matching
- M2: escape bash associative array keys with shell_words::quote
- M3: replace bare unwrap() with expect() in combine_shorts path
- M4: guard last().unwrap() with expect()
- M5: add recursion depth limit (128) in notation_text parser