### PR TITLE
feat: prefix bind-env autoname env var with command name

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -90,7 +90,7 @@ Defines a positional argument.
 # @arg vfd*,[`_choice_fn`]        multi-values + choice from fn + comma-separated list
 # @arg vxa~                       capture all remaining args
 # @arg vea $$                     bind-env
-# @arg veb $BE <PATH>             bind-named-env
+# @arg veb $VEB <PATH             bind-named-env
 ```
 
 ### `@option`
@@ -126,7 +126,7 @@ Defines an option argument.
 # @option    --ofd*,[`_choice_fn`]  multi-occurs + choice from fn + comma-separated list
 # @option    --oxa~                 capture all remaining args
 # @option    --oea $$               bind-env
-# @option    --oeb $BE <PATH>       bind-named-env
+# @option    --oeb $OEB <PATH>      bind-named-env
 ```
 
 ### `@flag`
@@ -144,7 +144,7 @@ Defines a flag argument. Flag is a special option that does not accept any value
 # @flag  -c              short only
 # @flag     --fd*        multi-occurs
 # @flag     --ea $$      bind-env
-# @flag     --eb $BE     bind-named-env
+# @flag     --eb $EB     bind-named-env
 ```
 
 ### `@env`
@@ -291,7 +291,7 @@ A-Z a-z 0-9 `!` `#` `$` `%` `*` `+` `,` `.` `/` `:` `=` `?` `@` `[` `]` `^` `_` 
 
  Link environment variables to params:
 
-- `$$`: Automatically use the param's name for the environment variable.
+- `$$`: Automatically use the parameter's name in uppercase as the environment variable name, prefixed with the command name (e.g. `--port $$` in command `serve` becomes `SERVE_PORT`).
 - `$`[_NAME_]: Use a specific environment variable name.
 
 ### description

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -65,7 +65,7 @@ impl Command {
     pub(crate) fn new(source: &str, root_name: &str) -> Result<Self> {
         let events = parse(source)?;
         let mut root = Command::new_from_events(&events)?;
-        root.share.borrow_mut().name = root
+        root.share.borrow_mut().root_name = root
             .get_metadata(META_BINNAME)
             .map(|v| v.to_string())
             .or_else(|| Some(root_name.to_string()));
@@ -74,6 +74,7 @@ impl Command {
             root.inherit_flag_options();
         }
         root.inherit_envs();
+        root.propagate_cmd_name_to_params();
         Ok(root)
     }
 
@@ -605,6 +606,24 @@ impl Command {
         }
         for subcmd in self.subcommands.iter_mut() {
             subcmd.inherit_flag_options();
+        }
+    }
+
+    fn propagate_cmd_name_to_params(&mut self) {
+        let root_name = self
+            .share
+            .borrow()
+            .root_name
+            .clone()
+            .unwrap_or_else(|| ROOT_NAME.to_string());
+        for param in self.flag_option_params.iter_mut() {
+            param.data_mut().root_name = Some(root_name.clone());
+        }
+        for param in self.positional_params.iter_mut() {
+            param.data_mut().root_name = Some(root_name.clone());
+        }
+        for subcmd in self.subcommands.iter_mut() {
+            subcmd.propagate_cmd_name_to_params();
         }
     }
 

--- a/src/command/share_data.rs
+++ b/src/command/share_data.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 #[derive(Default, Debug)]
 pub(crate) struct ShareData {
     pub(crate) scope: EventScope,
-    pub(crate) name: Option<String>,
+    pub(crate) root_name: Option<String>,
     pub(crate) fns: HashMap<String, Position>,
     pub(crate) cmd_fns: HashMap<String, Position>,
     pub(crate) cmd_pos: usize,
@@ -19,7 +19,7 @@ pub(crate) struct ShareData {
 
 impl ShareData {
     pub(crate) fn name(&self) -> String {
-        match &self.name {
+        match &self.root_name {
             Some(v) => v.clone(),
             None => ROOT_NAME.to_string(),
         }

--- a/src/param.rs
+++ b/src/param.rs
@@ -759,6 +759,7 @@ pub(crate) struct ParamData {
     pub(crate) default: Option<DefaultValue>,
     pub(crate) modifier: Modifier,
     pub(crate) env: Option<Option<String>>,
+    pub(crate) root_name: Option<String>,
 }
 
 impl ParamData {
@@ -770,6 +771,7 @@ impl ParamData {
             default: None,
             modifier: Modifier::Optional,
             env: None,
+            root_name: None,
         }
     }
 
@@ -823,7 +825,15 @@ impl ParamData {
     pub(crate) fn normalize_bind_env(&self, id: &str) -> Option<String> {
         let env = match self.env.as_ref()? {
             Some(v) => v.clone(),
-            None => sanitize_var_name(id).to_uppercase(),
+            None => {
+                let name = sanitize_var_name(id).to_uppercase();
+                match &self.root_name {
+                    Some(prefix) => {
+                        format!("{}_{}", sanitize_var_name(prefix).to_uppercase(), name)
+                    }
+                    None => name,
+                }
+            }
         };
         Some(env)
     }

--- a/tests/bind_env.rs
+++ b/tests/bind_env.rs
@@ -8,25 +8,25 @@ fn bind_env_flags_help() {
 #[rstest]
 fn bind_env_flags() {
     snapshot_bind_env!(args: ["flags"], envs: {
-        "FA1": "true",
+        "BIND_ENVS_FA1": "true",
         "FB2": "false",
         "FA": "true",
-        "FC": "true",
-        "FD": "true",
+        "BIND_ENVS_FC": "true",
+        "BIND_ENVS_FD": "true",
     });
 }
 
 #[rstest]
 fn bind_env_flags_bool_err() {
     snapshot_bind_env!(args: ["flags"], envs: {
-        "FA1": "v1",
+        "BIND_ENVS_FA1": "v1",
     });
 }
 
 #[rstest]
 fn bind_env_flags_bool_ok() {
     snapshot_bind_env!(args: ["flags", "--fa1"], envs: {
-        "FA1": "v1",
+        "BIND_ENVS_FA1": "v1",
     });
 }
 
@@ -38,18 +38,18 @@ fn bind_env_options_help() {
 #[rstest]
 fn bind_env_options() {
     snapshot_bind_env!(args: ["options"], envs: {
-        "OA1": "oa1",
-        "OA2": "oa2",
+        "BIND_ENVS_OA1": "oa1",
+        "BIND_ENVS_OA2": "oa2",
         "OA": "oa3",
         "OB": "ob",
-        "OC": "v1,v2",
-        "ODA": "oda",
-        "ODD": "odd",
-        "OCA": "a",
-        "OCC": "a",
-        "OFA": "abc",
-        "OFD": "abc,def",
-        "OXA": "oxa",
+        "BIND_ENVS_OC": "v1,v2",
+        "BIND_ENVS_ODA": "oda",
+        "BIND_ENVS_ODB": "odd",
+        "BIND_ENVS_OCA": "a",
+        "BIND_ENVS_OCC": "a",
+        "BIND_ENVS_OFA": "abc",
+        "BIND_ENVS_OFD": "abc,def",
+        "BIND_ENVS_OXA": "oxa",
     });
 }
 
@@ -57,7 +57,7 @@ fn bind_env_options() {
 fn bind_env_options_choice_err() {
     snapshot_bind_env!(args: ["options"], envs: {
         "OB": "ob",
-        "OCA": "oca",
+        "BIND_ENVS_OCA": "oca",
     });
 }
 
@@ -65,7 +65,7 @@ fn bind_env_options_choice_err() {
 fn bind_env_options_choice_ok() {
     snapshot_bind_env!(args: ["options", "--oca", "a"], envs: {
         "OB": "ob",
-        "OCA": "oca",
+        "BIND_ENVS_OCA": "oca",
     });
 }
 
@@ -73,7 +73,7 @@ fn bind_env_options_choice_ok() {
 fn bind_env_options_choice_fn_err() {
     snapshot_bind_env!(args: ["options"], envs: {
         "OB": "ob",
-        "OFA": "ofa",
+        "BIND_ENVS_OFA": "ofa",
     });
 }
 
@@ -85,7 +85,7 @@ fn bind_env_options_required_err() {
 #[rstest]
 fn bind_env_arg1() {
     snapshot_bind_env!(args: ["cmd_arg1"], envs: {
-        "VAL": "v1",
+        "BIND_ENVS_VAL": "v1",
     });
 }
 
@@ -99,46 +99,46 @@ fn bind_env_arg2() {
 #[rstest]
 fn bind_env_arg_choice_err() {
     snapshot_bind_env!(args: ["cmd_arg_with_choice"], envs: {
-        "VAL": "v1",
+        "BIND_ENVS_VAL": "v1",
     });
 }
 
 #[rstest]
 fn bind_env_arg_choice_fn_err() {
     snapshot_bind_env!(args: ["cmd_arg_with_choice_fn"], envs: {
-        "VAL": "v1",
+        "BIND_ENVS_VAL": "v1",
     });
 }
 
 #[rstest]
 fn bind_env_multi_arg_with_choice_fn_and_comma_sep() {
     snapshot_bind_env!(args: ["cmd_multi_arg_with_choice_fn_and_comma_sep"], envs: {
-        "VAL": "abc,def",
+        "BIND_ENVS_VAL": "abc,def",
     });
 }
 
 #[rstest]
 fn bind_env_cmd_three_required_args() {
     snapshot_bind_env!(args: ["cmd_three_required_args"], envs: {
-        "VAL1": "v1",
-        "VAL2": "v2",
-        "VAL3": "v3",
+        "BIND_ENVS_VAL1": "v1",
+        "BIND_ENVS_VAL2": "v2",
+        "BIND_ENVS_VAL3": "v3",
     });
 }
 
 #[rstest]
 fn bind_env_cmd_three_required_args_err() {
     snapshot_bind_env!(args: ["cmd_three_required_args"], envs: {
-        "VAL1": "v1",
-        "VAL2": "v2",
+        "BIND_ENVS_VAL1": "v1",
+        "BIND_ENVS_VAL2": "v2",
     });
 }
 
 #[rstest]
 fn bind_env_with_notation() {
     snapshot_bind_env!(args: ["cmd_for_notation"], envs: {
-        "OA": "oa",
-        "VAL": "v1",
+        "BIND_ENVS_OA": "oa",
+        "BIND_ENVS_VAL": "v1",
     });
 }
 #[rstest]

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -87,7 +87,7 @@ eval "$({argc_path} --argc-eval "$0" "$@")"
     }
 }
 
-pub fn build_script(script_dir: &TempDir, source: &str) -> PathBuf {
+pub fn build_script(script_dir: &TempDir, source: &str, root_name: &str) -> PathBuf {
     let has_fn = source.contains("()");
     let patched_source = source.replace(
         "{ :; }",
@@ -96,7 +96,7 @@ pub fn build_script(script_dir: &TempDir, source: &str) -> PathBuf {
     echo "$argc__fn" "$@"
 }"#,
     );
-    let mut output = argc::build(&patched_source, "prog", None).unwrap();
+    let mut output = argc::build(&patched_source, root_name, None).unwrap();
     if !has_fn {
         output.push_str("\n( set -o posix ; set ) | grep ^argc_");
     }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -43,7 +43,7 @@ macro_rules! snapshot {
         let values = argc::eval(argc::NativeRuntime, $source, &args, $path, $width).unwrap();
         let shell_code = argc::ArgcValue::to_bash(&values);
         let build_script_dir = $crate::fixtures::tmpdir();
-        let build_script_path = $crate::fixtures::build_script(&build_script_dir, $source);
+        let build_script_path = $crate::fixtures::build_script(&build_script_dir, $source, "prog");
         let build_output = $crate::fixtures::run_script(&build_script_path, &args[1..], &[]);
         let args = $args.join(" ");
         let data = format!(
@@ -73,7 +73,7 @@ macro_rules! snapshot_multi {
             $crate::fixtures::create_argc_script($source, "script.sh");
 
         let build_script_dir = $crate::fixtures::tmpdir();
-        let build_script_path = $crate::fixtures::build_script(&build_script_dir, $source);
+        let build_script_path = $crate::fixtures::build_script(&build_script_dir, $source, "prog");
 
         for args in $matrix.iter() {
             let args: Vec<String> = args.iter().map(|v| v.to_string()).collect();
@@ -231,7 +231,8 @@ macro_rules! snapshot_env {
         let build_output = {
             let build_script_dir = $crate::fixtures::tmpdir();
             let source = std::fs::read_to_string(&script_path).unwrap();
-            let build_script_path = $crate::fixtures::build_script(&build_script_dir, &source);
+            let root_name =  std::path::Path::new($script_file).file_stem().and_then(|s| s.to_str()).unwrap_or("prog");
+            let build_script_path = $crate::fixtures::build_script(&build_script_dir, &source, root_name);
             $crate::fixtures::run_script(&build_script_path, &args, &envs)
         };
 

--- a/tests/snapshots/integration__bind_env__bind_env_arg_choice_err.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_arg_choice_err.snap
@@ -4,10 +4,10 @@ expression: "format! (r#\"\n# OUTPUT\n{output}\n\n# BUILD_OUTPUT\n{build_output}
 ---
 
 # OUTPUT
-error: invalid value `v1` for environment variable `VAL` that bound to `[VAL]`
+error: invalid value `v1` for environment variable `BIND_ENVS_VAL` that bound to `[VAL]`
   [possible values: x, y, z]
 
 
 # BUILD_OUTPUT
-error: invalid value `v1` for environment variable `VAL` that bound to `[VAL]`
+error: invalid value `v1` for environment variable `BIND_ENVS_VAL` that bound to `[VAL]`
   [possible values: x, y, z]

--- a/tests/snapshots/integration__bind_env__bind_env_arg_choice_fn_err.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_arg_choice_fn_err.snap
@@ -4,10 +4,10 @@ expression: "format! (r#\"\n# OUTPUT\n{output}\n\n# BUILD_OUTPUT\n{build_output}
 ---
 
 # OUTPUT
-error: invalid value `v1` for environment variable `VAL` that bound to `[VAL]`
+error: invalid value `v1` for environment variable `BIND_ENVS_VAL` that bound to `[VAL]`
   [possible values: abc, def, ghi]
 
 
 # BUILD_OUTPUT
-error: invalid value `v1` for environment variable `VAL` that bound to `[VAL]`
+error: invalid value `v1` for environment variable `BIND_ENVS_VAL` that bound to `[VAL]`
   [possible values: abc, def, ghi]

--- a/tests/snapshots/integration__bind_env__bind_env_flags_bool_err.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_flags_bool_err.snap
@@ -4,8 +4,8 @@ expression: "format! (r#\"\n# OUTPUT\n{output}\n\n# BUILD_OUTPUT\n{build_output}
 ---
 
 # OUTPUT
-error: environment variable `FA1` has invalid value for param '--fa1'
+error: environment variable `BIND_ENVS_FA1` has invalid value for param '--fa1'
 
 
 # BUILD_OUTPUT
-error: environment variable 'FA1' has invalid value for param '--fa1'
+error: environment variable 'BIND_ENVS_FA1' has invalid value for param '--fa1'

--- a/tests/snapshots/integration__bind_env__bind_env_flags_help.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_flags_help.snap
@@ -9,11 +9,11 @@ How to bind env to param
 USAGE: bind-envs flags [OPTIONS]
 
 OPTIONS:
-      --fa1    [env: FA1]
-      --fa2    [env: FA2]
+      --fa1    [env: BIND_ENVS_FA1]
+      --fa2    [env: BIND_ENVS_FA2]
       --fa3    [env: FA]
-      --fc...  [env: FC]
-      --fd     [env: FD]
+      --fc...  [env: BIND_ENVS_FC]
+      --fd     [env: BIND_ENVS_FD]
   -h, --help
 
 
@@ -21,12 +21,12 @@ OPTIONS:
 # BUILD_OUTPUT
 How to bind env to param
 
-USAGE: prog flags [OPTIONS]
+USAGE: bind-envs flags [OPTIONS]
 
 OPTIONS:
-      --fa1    [env: FA1]
-      --fa2    [env: FA2]
+      --fa1    [env: BIND_ENVS_FA1]
+      --fa2    [env: BIND_ENVS_FA2]
       --fa3    [env: FA]
-      --fc...  [env: FC]
-      --fd     [env: FD]
+      --fc...  [env: BIND_ENVS_FC]
+      --fd     [env: BIND_ENVS_FD]
   -h, --help

--- a/tests/snapshots/integration__bind_env__bind_env_options.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_options.snap
@@ -15,7 +15,7 @@ argc_oc=([0]="v1" [1]="v2")
 argc_oca=a
 argc_occ=([0]="a")
 argc_oda=oda
-argc_odb=argc
+argc_odb=odd
 argc_ofa=abc
 argc_ofd=([0]="abc" [1]="def")
 argc_oxa=([0]="oxa")
@@ -34,7 +34,7 @@ argc_oc=([0]="v1" [1]="v2")
 argc_oca=a
 argc_occ=([0]="a")
 argc_oda=oda
-argc_odb=argc
+argc_odb=odd
 argc_ofa=abc
 argc_ofd=([0]="abc" [1]="def")
 argc_oxa=([0]="oxa")

--- a/tests/snapshots/integration__bind_env__bind_env_options_choice_err.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_options_choice_err.snap
@@ -4,10 +4,10 @@ expression: "format! (r#\"\n# OUTPUT\n{output}\n\n# BUILD_OUTPUT\n{build_output}
 ---
 
 # OUTPUT
-error: invalid value `oca` for environment variable `OCA` that bound to `--oca`
+error: invalid value `oca` for environment variable `BIND_ENVS_OCA` that bound to `--oca`
   [possible values: a, b]
 
 
 # BUILD_OUTPUT
-error: invalid value `oca` for environment variable `OCA` that bound to `--oca <OCA>`
+error: invalid value `oca` for environment variable `BIND_ENVS_OCA` that bound to `--oca <OCA>`
   [possible values: a, b]

--- a/tests/snapshots/integration__bind_env__bind_env_options_choice_fn_err.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_options_choice_fn_err.snap
@@ -4,10 +4,10 @@ expression: "format! (r#\"\n# OUTPUT\n{output}\n\n# BUILD_OUTPUT\n{build_output}
 ---
 
 # OUTPUT
-error: invalid value `ofa` for environment variable `OFA` that bound to `--ofa`
+error: invalid value `ofa` for environment variable `BIND_ENVS_OFA` that bound to `--ofa`
   [possible values: abc, def, ghi]
 
 
 # BUILD_OUTPUT
-error: invalid value `ofa` for environment variable `OFA` that bound to `--ofa <OFA>`
+error: invalid value `ofa` for environment variable `BIND_ENVS_OFA` that bound to `--ofa <OFA>`
   [possible values: abc, def, ghi]

--- a/tests/snapshots/integration__bind_env__bind_env_options_help.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_options_help.snap
@@ -7,36 +7,36 @@ expression: "format! (r#\"\n# OUTPUT\n{output}\n\n# BUILD_OUTPUT\n{build_output}
 USAGE: bind-envs options [OPTIONS] --ob <OB>
 
 OPTIONS:
-      --oa1 <OA1>     [env: OA1]
-      --oa2 <OA2>     [env: OA2]
+      --oa1 <OA1>     [env: BIND_ENVS_OA1]
+      --oa2 <OA2>     [env: BIND_ENVS_OA2]
       --oa3 <OA3>     [env: OA]
       --ob <OB>       [env: OB]
-      --oc [OC]...    [env: OC]
-      --oda <ODA>     [default: a] [env: ODA]
-      --odb <ODB>     [env: ODB]
-      --oca <OCA>     [possible values: a, b] [env: OCA]
-      --occ [OCC]...  [possible values: a, b] [env: OCC]
-      --ofa <OFA>     [env: OFA]
-      --ofd [OFD]...  [env: OFD]
-      --oxa <OXA~>    [env: OXA]
+      --oc [OC]...    [env: BIND_ENVS_OC]
+      --oda <ODA>     [default: a] [env: BIND_ENVS_ODA]
+      --odb <ODB>     [env: BIND_ENVS_ODB]
+      --oca <OCA>     [possible values: a, b] [env: BIND_ENVS_OCA]
+      --occ [OCC]...  [possible values: a, b] [env: BIND_ENVS_OCC]
+      --ofa <OFA>     [env: BIND_ENVS_OFA]
+      --ofd [OFD]...  [env: BIND_ENVS_OFD]
+      --oxa <OXA~>    [env: BIND_ENVS_OXA]
   -h, --help
 
 
 
 # BUILD_OUTPUT
-USAGE: prog options [OPTIONS] --ob <OB>
+USAGE: bind-envs options [OPTIONS] --ob <OB>
 
 OPTIONS:
-      --oa1 <OA1>     [env: OA1]
-      --oa2 <OA2>     [env: OA2]
+      --oa1 <OA1>     [env: BIND_ENVS_OA1]
+      --oa2 <OA2>     [env: BIND_ENVS_OA2]
       --oa3 <OA3>     [env: OA]
       --ob <OB>       [env: OB]
-      --oc [OC]...    [env: OC]
-      --oda <ODA>     [default: a] [env: ODA]
-      --odb <ODB>     [env: ODB]
-      --oca <OCA>     [possible values: a, b] [env: OCA]
-      --occ [OCC]...  [possible values: a, b] [env: OCC]
-      --ofa <OFA>     [env: OFA]
-      --ofd [OFD]...  [env: OFD]
-      --oxa <OXA~>    [env: OXA]
+      --oc [OC]...    [env: BIND_ENVS_OC]
+      --oda <ODA>     [default: a] [env: BIND_ENVS_ODA]
+      --odb <ODB>     [env: BIND_ENVS_ODB]
+      --oca <OCA>     [possible values: a, b] [env: BIND_ENVS_OCA]
+      --occ [OCC]...  [possible values: a, b] [env: BIND_ENVS_OCC]
+      --ofa <OFA>     [env: BIND_ENVS_OFA]
+      --ofd [OFD]...  [env: BIND_ENVS_OFD]
+      --oxa <OXA~>    [env: BIND_ENVS_OXA]
   -h, --help

--- a/tests/snapshots/integration__bind_env__bind_env_with_notation_help.snap
+++ b/tests/snapshots/integration__bind_env__bind_env_with_notation_help.snap
@@ -7,20 +7,20 @@ expression: "format! (r#\"\n# OUTPUT\n{output}\n\n# BUILD_OUTPUT\n{build_output}
 USAGE: bind-envs cmd_for_notation [OPTIONS] [XYZ]
 
 ARGS:
-  [XYZ]  [env: VAL]
+  [XYZ]  [env: BIND_ENVS_VAL]
 
 OPTIONS:
-      --OA <XYZ>  [env: OA]
+      --OA <XYZ>  [env: BIND_ENVS_OA]
   -h, --help
 
 
 
 # BUILD_OUTPUT
-USAGE: prog cmd_for_notation [OPTIONS] [XYZ]
+USAGE: bind-envs cmd_for_notation [OPTIONS] [XYZ]
 
 ARGS:
-  [XYZ]  [env: VAL]
+  [XYZ]  [env: BIND_ENVS_VAL]
 
 OPTIONS:
-      --OA <XYZ>  [env: OA]
+      --OA <XYZ>  [env: BIND_ENVS_OA]
   -h, --help

--- a/tests/snapshots/integration__env__env_help.snap
+++ b/tests/snapshots/integration__env__env_help.snap
@@ -25,7 +25,7 @@ ENVIRONMENTS:
 # BUILD_OUTPUT
 All kinds of @env
 
-USAGE: prog <COMMAND>
+USAGE: envs <COMMAND>
 
 COMMANDS:
   run

--- a/tests/snapshots/integration__env__env_help_subcmd.snap
+++ b/tests/snapshots/integration__env__env_help_subcmd.snap
@@ -19,7 +19,7 @@ ENVIRONMENTS:
 
 
 # BUILD_OUTPUT
-USAGE: prog run
+USAGE: envs run
 
 ENVIRONMENTS:
   TEST_EB*  required


### PR DESCRIPTION
## Summary

When using `$$` (autoname) for bind-env on flags, options, and positional arguments, the generated environment variable name is now prefixed with the command name.

## Motivation

Previously, `$$` only used the parameter's name in uppercase as the env var name. This could cause collisions when multiple commands have parameters with the same name. Prefixing with the command name avoids ambiguity and makes env vars self-documenting.

## Example

```sh

# @cmd A command named serve
# @flag --port $$    # before: PORT → now: SERVE_PORT
# @flag --host $$    # before: HOST → now: SERVE_HOST
```

Explicit env names via `$NAME` are unaffected:
```sh
# @flag --host $HOST_ENV   # stays HOST_ENV
```

