### PR TITLE
feat: redesign --argc-create args

### DIFF
--- a/src/bin/argc/completion.sh
+++ b/src/bin/argc/completion.sh
@@ -1,5 +1,5 @@
 # @option --argc-eval~ <FILE> <ARGS>                Use `eval "$(argc --argc-eval "$0" "$@")"`
-# @option --argc-create~ <RECIPES>                  Create a boilerplate argcfile
+# @option --argc-create~ <-|FILE> <RECIPES>         Create a boilerplate argc-based script
 # @option --argc-run~ <FILE> <ARGS>                 Run an argc-based script
 # @option --argc-build <FILE> <OUTPATH?>            Generate bashscript without argc dependency
 # @option --argc-mangen <FILE> <OUTDIR>             Generate man pages

--- a/src/bin/argc/main.rs
+++ b/src/bin/argc/main.rs
@@ -94,14 +94,34 @@ fn run() -> Result<i32> {
                 return run_command(&script_path, &shell, &args, envs, cwd);
             }
             "--argc-create" => {
-                if let Some((_, script_file)) = get_script_path(false) {
-                    bail!("Already exist {}", script_file.display());
-                }
-                let content = generate_boilerplate(&args[2..]);
-                let names = runner_script_names();
-                fs::write(&names[0], content)
-                    .with_context(|| format!("Failed to create {}", &names[0]))?;
-                println!("{} has been successfully created.", &names[0]);
+                let (outpath, task_args) = match args.get(2) {
+                    Some(v) if v == "-" => {
+                        if let Some((_, script_file)) = get_script_path(false) {
+                            bail!("Already exist {}", script_file.display());
+                        }
+                        let names = runner_script_names();
+                        (names[0].clone(), &args[3..])
+                    }
+                    Some(v) => {
+                        if Path::new(v).exists() {
+                            bail!("Already exist {}", v);
+                        }
+                        (v.clone(), &args[3..])
+                    }
+                    None => {
+                        if let Some((_, script_file)) = get_script_path(false) {
+                            bail!("Already exist {}", script_file.display());
+                        }
+                        let names = runner_script_names();
+                        (names[0].clone(), &args[2..])
+                    }
+                };
+                let content = generate_boilerplate(task_args);
+                fs::write(&outpath, content)
+                    .with_context(|| format!("Failed to create {outpath}"))?;
+                set_permissions(&outpath)
+                    .with_context(|| format!("Failed to set execute permission to '{outpath}'",))?;
+                println!("Successfully created {outpath}");
             }
             "--argc-build" => {
                 let (source, script_path, cmd_args) = parse_script_args(&args[2..])?;
@@ -161,7 +181,7 @@ fn run() -> Result<i32> {
                 let shell = runtime.shell_path()?;
                 let (source, script_path, cmd_args) = parse_script_args(&args[2..])?;
                 if !source.contains("--argc-eval") {
-                    bail!("Parallel only available for argc based scripts.")
+                    bail!("Parallel only available for argc based scripts")
                 }
                 parallel::parallel(runtime, &shell, &script_path, &cmd_args[1..])?;
             }
@@ -188,7 +208,7 @@ fn run() -> Result<i32> {
     } else {
         let shell = runtime.shell_path()?;
         let (script_dir, script_file) = get_script_path(true)
-            .ok_or_else(|| anyhow!("Argcfile not found, try `argc --argc-help` for help."))?;
+            .ok_or_else(|| anyhow!("Argcfile not found, try `argc --argc-help` for help"))?;
         let mut envs = HashMap::new();
         if let Some(cwd) = runtime.current_dir() {
             if env::var("ARGC_PWD").is_err() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -46,13 +46,14 @@ fn create() {
 }
 
 #[test]
-fn create_with_tasks() {
+fn create_argcfile_with_tasks() {
     let tmpdir = tmpdir();
     let path_env_var = get_path_env_var();
     Command::new(assert_cmd::cargo::cargo_bin!())
         .current_dir(tmpdir.path())
         .env("PATH", path_env_var.clone())
         .arg("--argc-create")
+        .arg("-")
         .args(["foo", "bar"])
         .assert()
         .success();
@@ -63,6 +64,22 @@ fn create_with_tasks() {
         .assert()
         .stdout(predicates::str::contains("TODO bar"))
         .success();
+}
+
+#[test]
+fn create_cli_with_tasks() {
+    let tmpdir = tmpdir();
+    let path_env_var = get_path_env_var();
+    Command::new(assert_cmd::cargo::cargo_bin!())
+        .current_dir(tmpdir.path())
+        .env("PATH", path_env_var.clone())
+        .arg("--argc-create")
+        .arg("mycli")
+        .args(["foo", "bar"])
+        .assert()
+        .success();
+    let contents = std::fs::read_to_string(tmpdir.join("mycli")).unwrap();
+    insta::assert_snapshot!(contents);
 }
 
 #[test]

--- a/tests/snapshots/integration__cli__create_cli_with_tasks.snap
+++ b/tests/snapshots/integration__cli__create_cli_with_tasks.snap
@@ -1,0 +1,20 @@
+---
+source: tests/cli.rs
+expression: contents
+---
+#!/usr/bin/env bash
+
+set -e
+
+# @cmd
+foo() {
+    echo TODO foo
+}
+
+# @cmd
+bar() {
+    echo TODO bar
+}
+
+# See more details at https://github.com/sigoden/argc
+eval "$(argc --argc-eval "$0" "$@")"


### PR DESCRIPTION
Because many times we don't just want to create an Argcfile, more often we need to create some utility scripts, and the default Argcfile creation mechanism is not convenient.

```diff
- --argc-create~ <RECIPES> Create a boilerplate argcfile
+ --argc-create~ <-|FILE> <RECIPES> Create a boilerplate argc-based script
```

```
$ argc --argc-create                        # Create Argcfile.sh
$ argc --argc-create - foo bar              # Create Argcfile.sh with tasks foo/bar
$ argc --argc-create mycli foo bar          # Create mycli with subcommands foo/bar
```