### PR TITLE
feat: compgen fallback comp file with dot prefix

### DIFF
--- a/src/compgen.rs
+++ b/src/compgen.rs
@@ -232,7 +232,17 @@ pub fn compgen<T: Runtime>(
         .collect();
 
     if !shell.is_generic() {
-        if let Some(path_value) = argc_value.and_then(|v| convert_arg_value(&v)) {
+        let mut path_value = argc_value.and_then(|v| convert_arg_value(&v));
+        if path_value.is_none()
+            && candidates.is_empty()
+            && (last_arg.starts_with("./") || last_arg.starts_with(".\\"))
+        {
+            path_value = Some(ArgcPathValue {
+                is_dir: false,
+                exts: vec![],
+            });
+        }
+        if let Some(path_value) = path_value {
             if let Some((value_prefix, value_filter, more_candidates)) = path_value.compgen(
                 runtime,
                 shell,

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -761,6 +761,31 @@ cmd() { :; }
 }
 
 #[test]
+fn fallback_comp_file_with_dot_prefix() {
+    let script = r###"
+# @cmd
+# @option --val1
+# @option --val2[`_choice_fn`]
+# @arg val3
+cmd() { :; }
+
+_choice_fn() {
+    :;
+}
+"###;
+
+    snapshot_compgen!(
+        script,
+        [
+            vec!["prog", "cmd", "--val1", "./Argc"],
+            vec!["prog", "cmd", "--val2", "./Argc"],
+            vec!["prog", "cmd", "./Argc"],
+        ],
+        argc::Shell::Bash
+    );
+}
+
+#[test]
 fn redirect_symbols() {
     let script = r###"
 # @option --oa

--- a/tests/snapshots/integration__compgen__fallback_comp_file_with_dot_prefix.snap
+++ b/tests/snapshots/integration__compgen__fallback_comp_file_with_dot_prefix.snap
@@ -1,0 +1,12 @@
+---
+source: tests/compgen.rs
+expression: data
+---
+************ COMPGEN `prog cmd --val1 ./Argc` ************
+./Argcfile.sh 
+
+************ COMPGEN `prog cmd --val2 ./Argc` ************
+./Argcfile.sh 
+
+************ COMPGEN `prog cmd ./Argc` ************
+./Argcfile.sh


### PR DESCRIPTION
When argc can't provide any value while compgening, we can force argc to compgen path by entering `./` or `.\`. This mechanism can greatly enhance the user's completion experience.