### PR TITLE
fix(matcher): respect explicit options before subcommand with bind-env

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -597,6 +597,14 @@ impl<'a: 'b, 'b, T: Runtime> Matcher<'a, 'b, T> {
         self.split_last_arg_at
     }
 
+    fn parent_has_explicit_flag_option(&self, level: usize, param_id: &str) -> bool {
+        (0..level).any(|parent_level| {
+            self.flag_option_args[parent_level]
+                .iter()
+                .any(|(_, _, name)| name == &Some(param_id))
+        })
+    }
+
     #[cfg(feature = "eval")]
     fn to_arg_values_base<'x>(&'x self, bind_envs: &BindEnvs<'a, 'x>) -> Vec<ArgcValue> {
         let mut output = vec![];
@@ -640,13 +648,18 @@ impl<'a: 'b, 'b, T: Runtime> Matcher<'a, 'b, T> {
                     })
                     .collect();
                 if args.is_empty() {
-                    if let Some(env_values) = bind_envs.flag_options[level].get(param.id()) {
-                        if param.is_flag() {
-                            if is_true_value(env_values[0]) {
+                    let skip_bind_env = param.is_inherited()
+                        && level > 0
+                        && self.parent_has_explicit_flag_option(level, param.id());
+                    if !skip_bind_env {
+                        if let Some(env_values) = bind_envs.flag_options[level].get(param.id()) {
+                            if param.is_flag() {
+                                if is_true_value(env_values[0]) {
+                                    args = vec![("", env_values.as_slice())];
+                                }
+                            } else {
                                 args = vec![("", env_values.as_slice())];
                             }
-                        } else {
-                            args = vec![("", env_values.as_slice())];
                         }
                     }
                 }
@@ -774,6 +787,16 @@ impl<'a: 'b, 'b, T: Runtime> Matcher<'a, 'b, T> {
                     if !param.multiple_occurs() && values_list.len() > 1 {
                         return Some(MatchError::NotMultipleArgument(level, param.long_name()));
                     }
+                }
+            }
+
+            for param in cmd
+                .flag_option_params
+                .iter()
+                .filter(|p| p.is_inherited() && level > 0)
+            {
+                if self.parent_has_explicit_flag_option(level, param.id()) {
+                    check_flag_option_bind_envs.swap_remove(param.id());
                 }
             }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -432,6 +432,10 @@ impl FlagOptionParam {
         self.inherited = true;
     }
 
+    pub(crate) fn is_inherited(&self) -> bool {
+        self.inherited
+    }
+
     pub(crate) fn create_help_flag(short: Option<&str>, long_prefix: &str, describe: &str) -> Self {
         let mut param_data = ParamData::new("help");
         param_data.describe = describe.to_string();

--- a/tests/bind_env.rs
+++ b/tests/bind_env.rs
@@ -145,3 +145,59 @@ fn bind_env_with_notation() {
 fn bind_env_with_notation_help() {
     snapshot_bind_env!(args: ["cmd_for_notation", "-h"], envs: {});
 }
+
+#[rstest]
+fn bind_env_inherit_flag_options_before_subcmd() {
+    let script = r###"
+# @meta inherit-flag-options
+# @option --opt $ENV <PATH>  Option
+
+# @cmd
+cmd() {
+    echo "argc_opt=${argc_opt:?}"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"
+"###;
+    let (script_path, _, script_file) =
+        crate::fixtures::create_argc_script(script, "inherit-bind-env.sh");
+    let args: Vec<String> = vec!["--opt".into(), "arg".into(), "cmd".into()];
+    let envs = vec![("ENV", "env")];
+    let output = crate::fixtures::run_script(&script_path, &args, &envs);
+    assert!(
+        output.contains("argc_opt=arg"),
+        "expected explicit option before subcommand, got: {output}"
+    );
+    script_file.close().unwrap();
+}
+
+#[rstest]
+fn bind_env_inherit_flag_options_before_and_after_subcmd() {
+    let script = r###"
+# @meta inherit-flag-options
+# @option --opt $ENV <PATH>  Option
+
+# @cmd
+cmd() {
+    echo "argc_opt=${argc_opt:?}"
+}
+
+eval "$(argc --argc-eval "$0" "$@")"
+"###;
+    let (script_path, _, script_file) =
+        crate::fixtures::create_argc_script(script, "inherit-bind-env2.sh");
+    let args: Vec<String> = vec![
+        "--opt".into(),
+        "arg1".into(),
+        "cmd".into(),
+        "--opt".into(),
+        "arg2".into(),
+    ];
+    let envs = vec![("ENV", "env")];
+    let output = crate::fixtures::run_script(&script_path, &args, &envs);
+    assert!(
+        output.contains("argc_opt=arg2"),
+        "expected last explicit option after subcommand to win, got: {output}"
+    );
+    script_file.close().unwrap();
+}


### PR DESCRIPTION
## Summary

Fix inherited bind-env options ignoring explicit CLI values when the option is passed before the subcommand with `@meta inherit-flag-options`.

## Motivation

With `@meta inherit-flag-options` and `@option --opt $ENV`, running:

```bash
ENV=env argc --opt arg test-cmd
```

incorrectly set `argc_opt=env` instead of `argc_opt=arg`. Passing `--opt arg` after the subcommand worked.

The subcommand-level inherited param fell back to bind-env even when the parent command level had already parsed an explicit value.

## Changes

- Add `parent_has_explicit_flag_option()` helper in `matcher.rs`
- Skip inherited bind-env fallback at subcommand levels when a parent level already parsed the option
- Skip inherited bind-env validation in the same scenario
- Add `FlagOptionParam::is_inherited()` accessor
- Add integration tests for before-subcommand and before+after-subcommand cases

## Tests

```bash
cargo test
```

- 218 tests passed (including 2 new bind-env inherit tests)

## Notes

- Only affects inherited params with bind-env; regular inherited options already worked via parent-level output
- Explicit values after the subcommand still win (last assignment in bash eval)

Fixes #415