### PR TITLE
feat(cli): add --argc-tasks flag to list Argcfile subcommands

### DIFF
--- a/src/bin/argc/completion.sh
+++ b/src/bin/argc/completion.sh
@@ -7,6 +7,7 @@
 # @option --argc-compgen <SHELL> <FILE> <ARGS>      Generate completion candidates
 # @option --argc-export <FILE>                      Export command line definitions as json
 # @option --argc-parallel~ <FILE> <ARGS>            Run functions in parallel
+# @flag --argc-tasks                                List @cmd task names in the Argcfile
 # @flag --argc-script-path                          Print current argcfile path
 # @flag --argc-shell-path                           Print current shell path
 # @flag --argc-help                                 Print help information

--- a/src/bin/argc/main.rs
+++ b/src/bin/argc/main.rs
@@ -185,6 +185,39 @@ fn run() -> Result<i32> {
                 }
                 parallel::parallel(runtime, &shell, &script_path, &cmd_args[1..])?;
             }
+            "--argc-tasks" => {
+                let json_output = args.iter().skip(2).any(|v| v == "--json");
+                let file_args: Vec<&String> = args
+                    .iter()
+                    .skip(2)
+                    .filter(|v| v.as_str() != "--json")
+                    .collect();
+                let (source, root_name) = if file_args.is_empty() {
+                    let (_, script_file) =
+                        get_script_path(true).ok_or_else(|| anyhow!("Argcfile not found."))?;
+                    let script_path = script_file.to_string_lossy().to_string();
+                    let source = fs::read_to_string(&script_file)
+                        .with_context(|| format!("Failed to load script at '{script_path}'"))?;
+                    let name = get_script_name(&script_path)?;
+                    let name = name.strip_suffix(".sh").unwrap_or(name);
+                    (source, name.to_string())
+                } else {
+                    let script_file = normalize_script_path(file_args[0]);
+                    let source = fs::read_to_string(&script_file)
+                        .with_context(|| format!("Failed to load script at '{script_file}'"))?;
+                    let name = get_script_name(&script_file)?;
+                    let name = name.strip_suffix(".sh").unwrap_or(name);
+                    (source, name.to_string())
+                };
+                let tasks = argc::list_tasks(&source, &root_name)?;
+                if json_output {
+                    println!("{}", serde_json::to_string_pretty(&tasks)?);
+                } else {
+                    for task in &tasks {
+                        println!("{}", task.name);
+                    }
+                }
+            }
             "--argc-script-path" => {
                 let (_, script_file) =
                     get_script_path(true).ok_or_else(|| anyhow!("Argcfile not found."))?;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -904,6 +904,26 @@ impl Command {
 
 #[cfg(feature = "export")]
 #[derive(Debug, Serialize)]
+pub struct TaskInfo {
+    pub name: String,
+    pub aliases: Vec<String>,
+}
+
+#[cfg(feature = "export")]
+pub(crate) fn list_tasks(source: &str, root_name: &str) -> Result<Vec<TaskInfo>> {
+    let cmd = Command::new(source, root_name)?;
+    Ok(cmd
+        .subcommands
+        .iter()
+        .map(|subcmd| TaskInfo {
+            name: subcmd.cmd_name(),
+            aliases: subcmd.list_alias_names(),
+        })
+        .collect())
+}
+
+#[cfg(feature = "export")]
+#[derive(Debug, Serialize)]
 pub struct CommandValue {
     pub name: String,
     pub describe: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub use argc_value::ArgcValue;
 #[cfg(feature = "build")]
 pub use build::build;
 #[cfg(feature = "export")]
-pub use command::CommandValue;
+pub use command::{CommandValue, TaskInfo};
 #[cfg(feature = "compgen")]
 pub use compgen::{compgen, compgen_kind, CompKind, COMPGEN_KIND_SYMBOL};
 #[cfg(feature = "completions")]
@@ -60,4 +60,9 @@ pub fn eval<T: Runtime>(
 pub fn export(source: &str, root_name: &str) -> Result<CommandValue> {
     let cmd = command::Command::new(source, root_name)?;
     Ok(cmd.export())
+}
+
+#[cfg(feature = "export")]
+pub fn list_tasks(source: &str, root_name: &str) -> Result<Vec<TaskInfo>> {
+    command::list_tasks(source, root_name)
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -270,6 +270,40 @@ fn script_path() {
 }
 
 #[test]
+fn argc_tasks() {
+    argc_bin()
+        .arg("--argc-tasks")
+        .assert()
+        .stdout(predicates::str::contains("test\n"))
+        .stdout(predicates::str::contains("check\n"))
+        .stdout(predicates::str::contains("fix\n"))
+        .success();
+}
+
+#[test]
+fn argc_tasks_json() {
+    let output = argc_bin()
+        .args(["--argc-tasks", "--json"])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    assert!(stdout.contains(r#""name": "test""#));
+    assert!(stdout.contains(r#""name": "check""#));
+    assert!(stdout.contains(r#""c""#));
+}
+
+#[test]
+fn argc_tasks_file() {
+    let path = locate_script("examples/demo.sh");
+    argc_bin()
+        .args(["--argc-tasks", &path])
+        .assert()
+        .stdout(predicates::str::contains("upload\n"))
+        .stdout(predicates::str::contains("download\n"))
+        .success();
+}
+
+#[test]
 fn shell_path() {
     argc_bin()
         .arg("--argc-shell-path")


### PR DESCRIPTION
## Summary

Add `--argc-tasks` to list every `@cmd` task defined in the discovered Argcfile (or an explicit script path). Plain output prints one task name per line; pass `--json` for structured output with aliases.

## Motivation

Argcfile-based projects with many `@cmd` tasks had no scriptable way to enumerate task names — users had to parse `argc --help` output. This mirrors patterns like `just --list` and `cargo --list`, enabling IDE task pickers, CI summaries, and shell validation (`argc --argc-tasks | grep -qx "$task"`).

Fixes #416

## Changes

- Add `TaskInfo` struct and `list_tasks()` in `src/command/mod.rs`
- Export public `argc::list_tasks()` API in `src/lib.rs`
- Handle `--argc-tasks` in `src/bin/argc/main.rs`:
  - Auto-discover Argcfile when no file argument is given
  - Optional explicit script path
  - `--json` flag for structured output
- Document flag in `src/bin/argc/completion.sh`
- Add regression tests in `tests/cli.rs`

## Tests

- `cargo test argc_tasks` — 3 passed (plain text, JSON, explicit file)
- `cargo fmt --all --check` — passed
- `cargo clippy --all-targets -- -D warnings` — passed

## Notes

- Plain-text output lists task names only (not aliases), matching the issue example. Aliases appear in `--json` output.
- Only root-level `@cmd` tasks are listed; nested subcommands are out of scope for this flag.
